### PR TITLE
adding minutes and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
-# trainers
-Repository for the Instructor Trainers community
+# The Carpentry Instructor Trainers Group
+
+## Purpose and Scope
+
+This is the group of certified instructor trainers. We certify new instructors and collaborative develop the instructor training cirriculum.
+
+## What We Do
+What we do is described in detail in the instructor trainer agreement policy document: https://github.com/carpentries/policies/blob/master/trainer-agreement.md
+
+Befiefly, we carry out tasks including:
+- develop and teach the Instructor Training Curriculum: http://swcarpentry.github.io/instructor-training/
+- host/attend monthly discussion and business meetings: http://pad.software-carpentry.org/trainers
+- host demo sessions for instructor checkout: http://pad.software-carpentry.org/teaching-demos
+
+## Steering Committee Liaison
+- Christina Koch
+
+## Current Members
+- Erin Becker (United States)
+- Martin Callaghan (United Kingdom)
+- Karen Cranston (United States)
+- Steve Crouch (United Kingdom)
+- Neal Davis (United States)
+- Tim Dennis (United States)
+- Jonah Duckles (New Zealand)
+- Rayna Harris (United States)
+- Christopher Hamm (United States)
+- Kari Jordan (United States)
+- Alix Keener (United States)
+- Christina Koch (United States)
+- Mateusz Kuzak (Netherlands)
+- Karin Lagesen (Norway)
+- Mark Laufersweiler (United States)
+- Sue McClatchy (United States)
+- Aleksandra Nenadic (United Kingdom)
+- Lex Nederbragt (Norway)
+- Jeff Oliver (United States)
+- Aleksandra Pawlik (New Zealand)
+- Ariel Rokem (United States)
+- Maneesha Sane (United States)
+- Tracy Teal (United States)
+- Fiona Tweedie (Australia)
+- Anelda van der Walt (South Africa)
+- Allegra Via (Italy)
+- Jason Williams (United States)
+- Alistair Walsh (Australia)
+- Belinda Weaver (Australia)
+- Greg Wilson (Canada)
+- Karen Word (United States)
+- Naupaka Zimmerman (United States)
+

--- a/minutes/2016-11.txt
+++ b/minutes/2016-11.txt
@@ -1,0 +1,175 @@
+Trainers Meeting Nov 22 or 24, 2016
+
+Attending Nov 22 (15:00 Eastern time)
+	* Greg Wilson
+	* Anelda van der Walt
+	* Maneesha Sane
+	* Karen Cranston
+	* Sue McClatchy
+	* Erin Becker
+	* Ariel Rokem
+	* Christina Koch
+	* Garrett Grolemund
+	* Jonah Duckles
+
+Attending Nov 24 (15:00 Eastern time)
+	* Greg Wilson
+	* Lex Nederbragt
+	* Karin Lagesen
+	* Allegra Via
+	* Mateusz Kuzak
+	* Rayna Harris
+	* Jason Williams
+
+Agenda
+	1. Trainer availability for Jan-June 2017
+	1. Recap of recent instructor training events (and others)
+	1. Review update message to instructors (see below)
+	1. Discuss explicit instructor agreement (see below)
+	1. Regular demo sessions (see below)
+	1. Volunteers to record pretend demo sessions for trainees to review
+
+1. Trainer Availability for Jan-June 2017
+
+How many workshops can you teach or co-teach in person (involving travel) or online (no travel), and what constraints are there on your availability?
+
+	* Erin Becker - 2 online, any month ok but later in year better
+	* Karen Cranston - can commit to 1, maybe 2; Feb / early March good; as is June (moving sometime in between)
+	* Steve Crouch - 1 in person (already scheduled for March 16-17), 2 online (late Jan-mid Feb, Apr-Jun)
+	* Neal Davis - can do 1 or 2 online, opening up more in April--May incl. possibility of travel; will try to do one at UIUC/NCSA in May
+	* Garrett Grolemund
+	* Rayna Harris - 1 in person, 2 online: Feb and April only
+	* Christina Koch- 1 in person, 1 online; should be free all dates except HTCondor week (which is usually mid/end May)
+	* Mateusz Kuzak - 2 in person, 2 online, whole year equally good, no special constraints but I would need to arrange visa for US
+	* Karin Lagesen - 1 in person iff in europe, 1-2 online iff on american time
+	* Sue McClatchy - Jan (light duty only; also teaching in Mexico & Boston + grant deadline in Jan); latter half of March, all of April, May 
+	* Lex Nederbragt - 1 online co-teaching, could perhaps do another one, or assist with one, prefer mainland Europe daytime. Uncertain about travelling to in-person one (in Europa)
+	* Aleksandra Pawlik 1 online per 2 months; in person: hard to say :-( Hopefully I can get a permission for one travel a year
+	* Ariel Rokem - Planning to teach at UW and at NYU CDS some time during this period. Can do a couple of online support, as needed. On family leave starting May (tfu, tfu).
+	* Tracy Teal - not available unless associated with particular events
+	* Fiona Tweedie
+	* Anelda van der Walt - 1 in person preferably between 18 March - 4 April (School holidays), with some warning I could do online ones from Feb - June in any time zone. 
+	* Allegra Via-1/2 in person depending on the dates - 1 online if European time (despite I've no idea about how to manage an online course and would need to feel much more confident. Currently, confidence in running such a course online is ~zero).
+	* Alistair Walsh
+	* Belinda Weaver  - possibly doing one Jan 2017 (discussing with Jonah). Doing one  in May 2017 in Portland for librarians.  Can teach one or two more and can travel depending on work commitments. 
+	* Greg Wilson - 2 per month online, 1 trip in first half of 2017
+	* Jason Williams - after Feb (and certification) should be able to do at least one travel workshop and 1-2 online. Summer is always busy with conferences
+
+On average: 1 serious inquiry about parternship a week. 50 sets of people a year. realistically 20 events per year. 17+4  trainers already or  in the pipeline. We can handle the load, but also need to think about the followup like demos and discussion sessions. 
+
+2. Recap of Recent Instructor Training Events
+
+	* 2016-10-20-ttt-online (Greg): Michigan State & U Oklahoma / online
+		* also, Rayna wrote a blog after this workshop, comparing and contrasting teaching online and in person. you can read it here: http://software-carpentry.org/blog/2016/10/instructrortraining.html
+	* 2016-10-24-ttt-uwmadison (Christina & Greg): U Wisconsin / on site
+		* Christina: was not sure how it would go to include random regional people who were interested, but turned out to be really valuable, especially for that audience
+	* 2016-10-27-ttt-online (Greg): open / online
+		* See Erin's post at http://www.datacarpentry.org/blog/open-instructor-training/
+	* 2016-11-03-ttt-cuny (Greg): CUNY / on site
+		* Notable for concern reported that some learners worry that focus on computation might devalue their existing skills
+	* 2016-11-07-ttt-online (Greg): Jackson Lab / online
+	* 2016-11-15-ttt-online (Lex & Greg): open / online
+
+GW: Online working as well as in person with a few caveats
+	* works well when we have enough people at each place for group teaching
+	* doesn't work well when students have to pair up via the web because audio/video recording fails. if we could keep them in blue jeans we could do it, but that is very expensive and technically challenging. 
+	* etherpad is repeatidly failing under a heavy load. Lex and Steve have been using Google Docs. Maybe we should switch??? bonus- we can paste in images and all sorts of things. Will do some pilot runs in January
+LN: 2nd online training, 1st doing 2 half days.
+	* misses not being able to walk around during video recording session, but it scales well
+	* very happy overall. load sharing worked
+GW: for one session, we had Sue step in to take notes anonymously, which worked very well and got the feedback from the students... alllowed for more candid response. For live workshops, we can have the instructors leave and the host manage the feedback. JW - note that we want to keep the quality high and consistent
+
+3. Review Update Message to Instructors
+
+Please see update at the bottom from Erin Becker
+
+We have made some changes to our processes in the past few months that we hope will help us serve our community better, and we'd like to take this opportunity to communicate them to you. If you have any questions, comments, or concerns, you can always contact us by mailing admin@software-carpentry.org.
+
+1. We have an online  tool that is called AMY which  we use to manage training, instructors, and workshops, so that you can log in using your GitHub username and password. (We hope to support Google logins by January.) Please take a moment to go to https://amy.software-carpentry.org/account/login/ and update your profile information to let us know what you're comfortable teaching and what part of the world you're in so that we can do a better job of matching you with workshops.
+
+2. Please also make sure that AMY has an up-to-date email address for you so that we can contact you whenever there are important changes to things like our data privacy policy (which you can view at http://software-carpentry.org/privacy/). This is separate from subscribing to the instructors' mailing list (http://lists.software-carpentry.org/listinfo/instructors): you only need to join the latter if you want to hear about upcoming workshops that need instructors, but we now require the former so that we have a sure way to reach people when important rules change.
+
+3. We now require that when instructors agree to teach a workshop, they also agree to give at least one week's notice if they will be unable to make it. If they do not, they are required to reimburse any non-refundable travel or accommodation costs that the host may already have incurred on their behalf. The SCF may waive this requirement in special circumstances, but the decision to do so rests solely with the Steering Committee. If an instructor is required to reimburse costs, but refuses to do so, the SCF may ban that person from future Software Carpentry activities. If an instructor fails to provide adequate notice of withdrawal more than once, the SCF reserves the right to suspend them from the list of instructors.
+
+4. We are very pleased to announce that Library Carpentry is now up and running at http://librarycarpentry.github.io/. Library Carpentry is made by and for librarians to help people automate repetitive tasks, create, maintain, and analyze data, work effectively with IT and systems colleagues, and better understand the use of software in research. If you would like to learn more, help develop lessons, or help teach, please see their website or head over to https://gitter.im/weaverbel/LibraryCarpentry.
+
+5. Code of Conduct [Greg to fill in]
+
+Again, if you have any questions, comments, or concerns, you can always contact us by mailing admin@software-carpentry.org.
+
+Thanks again for all your contributions to Data Carpentry and Software Carpentry,
+[NAME]
+
+	* DC is working on a new privacy policy that we hope will also be adopted by SWC. Please check with Tracy on status.
+	* The missed workshop policy is also undergoing revisions on the DC side. 
+
+4. Explicit Instructor Agreement
+
+Library Carpentry instructor agreement taken from http://pad.software-carpentry.org/library-carpentry
+
+	* I agree to use one or more of the Library Carpentry modules in my Library Carpentry workshops.
+	* I understand that the secondary learning outcomes of Library Carpentry workshops are as important as their stated goals. These include (but are not excluded to) learners a) being introduced to the value of non-proprietary file formats, good data management, peer-to-peer learning, not always using GUIs, computational approaches to working with library data; and b) feeling more confident to admit what they don't know, collaborate with developers, pursue further self-directed learning.
+	* I agree to support and encourage learners and I endeavour to ensure that attendees have an enjoyable and fulfilling experience.
+	* I agree to honour the Software Carpentry code of conduct.
+	* I am aware that as Library Carpentry grows, it has an ambition for the lead instructor of every Library Carpentry workshop to have undergone Software/Data Carpentry instructor training. I am aware that by becoming a Software/Data Carpentry approved instructor I can help grow and enrich the Library Carpentry community. Having therefore been a instructor at a Library Carpentry workshop, I agree to consider becoming a Software/Data Carpentry approved Instructor.
+
+GW: this is above and beyond the code of contact. Again, this will be up on github for commenting and editing.
+Great way to clarify expectations
+RH: can we also include some language about what the carpentries will provide back to its volunteer instructors?
+
+5. Regular Demo Sessions
+
+Just as we have regular times for discussion sessions, we should institute regular times for demo sessions.  I propose 10:00-11:00 Eastern and 18:00-19:00 Eastern (same hours as discussion sessions) on Thursdays (so as not to conflict with discussion sessions).  Weekly sessions will begin the second week of January, and each trainer will be asked to supervise one every two months.
+	* +1 RH. Regular is good. Do we need of offer some ad hoc if a trainee has a hard conflict?
+		* Yes: GVW can field the irregulars
+	* +1 KL to this too. Makes it easier to fit in my schedule
+	* +1 AvdW definitely easier to plan
+	* +1 KC
+	* +1 EB
+	* -1 AR - I can't commit to your designated times. I would like to set my own times
+	* +1 CK - the fewer decisions I have to make the better
+	* +1 MK
+	* +1 LN but make very clear to trainees that other days are offered in case the regular day is not possible
+	* +1 I do agree with Lex
+
+6. Volunteers to Record Demo Session to Show to Trainees
+
+We would like to record a pretend demo session with 3 people playing the roles of trainees doing demos and 1 person playing the role of the trainer; one "trainee" should do a really bad demo, one should do a good one, and the third "trainee" will just be there to add more comments and bulk up numbers. Please let us know if you would like to help: we plan to do the recording on November 30, and it should take about an hour. (inspired by this issue: https://github.com/swcarpentry/instructor-training/issues/287 )
+	* +1 RH this sounds like a cool idea! It should be fairly simple to do the recording and it will be an excellent resource for those fresh our of instructor training 
+	* +1 AvdW Could help. The demo sessions is definitely still something that trips people up. 
+	* +1 CK (I have limited time that day, but would be keen)
+	* +1 KC and Nov 30 works for me
+	* +1 RH - i'll show up and participate
+
+LN: see also teaching-demo tips PR https://github.com/swcarpentry/instructor-training/pull/345
+
+
+7. Trainer training assignment for certification
+
+- something useful, but that isn't a great learning experience necessarily, might be more checklists for effective speaking, teaching, lesson design or workshop organization
+	- a guide for engaging online (to github, etherpad, bluejeans, hangouts), making clear the "norms" of how we organize ourselves online
+- leading one of these calls, teaching or discussing a paper or piece of research about teaching/learning
+- go through the current instructor training material + review lesson/learning objectives and improve if necessary. ;)
+- Review of trainee PRs (required for instructor certification) 
+- Co-lead demo/discussion session
+
+Learn about socrative!  
+http://swcarpentry.github.io/instructor-retreat-2015/ - see 8:00 UTC for Kate's video on Socrative
+
+Discussion around creating a lesson design elective from the things we throw out when we focus on preparing them to teach their first workshop, not create lessons.
+
+Allegra: individual project for instructor training - building a semester long train the trainer course
+Mateusz: 10 simple rules for building local instructor communities
+
+ODI Train the Trainers: https://theodi.org/courses/train-the-trainer
+
+PLOS 10 simple rule: http://collections.plos.org/ten-simple-rules
+Allegra: It may help to know that we (Via A, De Las Rivas J, Attwood TK, Landsman D, Brazas MD, Leunissen JA, Tramontano A, Schneider MV.) published a ten-simple-rules paper on training in 2011 - "Ten simple rules to develop a short bioinformatics training course". 
+
+See open science workflows: https://101innovations.wordpress.com/
+
+Ideas for projects:
+	* Videoing an online video training lesson
+
+
+

--- a/minutes/2017-01.txt
+++ b/minutes/2017-01.txt
@@ -1,0 +1,103 @@
+Software and Data Carpentry Trainers Meeting 2017-01-10
+
+Please add yourself to the sign-in list below.
+	* Greg Wilson
+	* Jason Williams
+	* Jonah Duckles
+	* Lex Nederbragt
+	* Tim Dennis
+	* Karin Lagesen
+	* Sue McClatchy
+	* Mateusz Kuzak
+	* Anelda van der Walt
+	* Rayna Harris
+	* Tracy Teal
+	* Karen Cranston
+	* Maneesha Sane
+	* Erin Becker (popped on at end)
+
+Agenda
+	1. Succession
+	2. Publishing Instructor Training Materials
+	3. Recent Instructor Training Events
+	4. Upcoming Training Events
+	5. Reorganizing Trainer Training
+
+1. Succession
+
+	* The EDs and staff are discussing plans to reallocate DIT responsibilities
+		* Maneesha and Erin to take over some responsibilities, new co-hire from both Carpentrires being worked out
+		* Greg to continue being involed in instructor-training
+
+2. Publishing Instructor Training Materials
+
+	* Greg W. and Christina K. hope to tidy up and publish a hard copy the existing course materials in Q1/Q2 2017
+		* experiment in material to hand out
+
+3. Recent Instructor Training Events
+
+	* 2016-11-24 (Met Office): Steve C.
+	* 2016-11-29 (NeSI): Aleksandra P.
+	* 2016-12-01 (PNNL): Ariel R.
+	* 2016-12-12 (UIUC): Neal D.
+	* 2016-12-13 (UCSF): Erin B. & Tracy T.
+	* 2016-12-14 (online for Aus/NZ): Aleksandra P. Belinda W., Alistair W.
+		* timezones an issue for this one (daylight saving change nightmares); need a clear pointer to time relative to everyone's timezone/location
+			* having it as an event on a google calendar somewhere is the best thing I've ever seen.
+	* 2016-12-15 (online): Greg W.
+	* two organized by instructor trainers (not Greg) for partner organizations
+	* Tracy and Erin used the new "introduction to introductions" material at the end and it worked really well. practiced introducing themselves and how it set the tone for the workshop. they will do a blog.
+	* Q? Are we sharing our survey monkey results? not sure. 
+	* Lots of bumps in the road for the Aussie event (see above) 
+	* now have regularily scheduled demos http://pad.software-carpentry.org/teaching-demos
+	* etherpad of etherpads http://pad.software-carpentry.org/pad-of-pads
+	* Software Carpentry Community Calendar https://software-carpentry.org/join/ (looks like it shows events in your local timezone, but you can also subscribe)
+		* most of us cannot modify/add events, though
+		* add a TTT calendar?
+
+4. Upcoming Training Events
+
+	* 2017-01-11 online (NIH, Oklahoma State): Greg W.
+	* 2017-01-19 online (DOE ECP): Greg W.
+	* 2017-01-25 (NZ): Aleksandra P.
+	* 2017-02-09 (Utah State): Karen C. + 1 remote needed (Neal Davis can help)
+	* 2017-02-13 (NIH remote): Greg W. + 1 more needed (Jason?)
+	* 2017-03-07 (NIH remote): instructors needed (possibly Karin) (Sue M. is available for this)
+	* 2017-03-16 (Oxford): Steve C.
+	* 2017-03-24 (Puerto Rico): Rayna H. and Sue McC. Tracy might be actually going to Puerto Rico then. 
+	* 2017-XX-XX (Aarhus, Denmark): need remote instructor in Europe (ask Lex if after mid-March)
+
+Others on the horizon in 2017: Space Telescope Science Institute (remote), NIST, Leeds, Sheffield, UCL
+
+5. Reorganizing Trainer Training
+
+	* Having people blog their way through books isn't working well +1
+		* Just as spreading regular instructor training over multiple weeks didn't work as well as doing it in two days
+	* So:
+		* Change what people do?
+		* Make it a 
+			* two-day (?)in-person event? -1 KC very challenging for travel -1 RH -1 KL +1 JW
+			* annual (?) 
+			* slack +1RH
+		* Coordinate with CarpentryCon (?) - would work if you want a 2 day in person thing
+
+Feedback:
+	* Mixed feeling about 2 day in person - more challenging for people where it doesn't fall into their jobs. Would have to take vacation days to do an in person event.
+	* From Karen, blogging the way through the books doesn't work, because there's no interaction, either do book club, or Slack, or watch an instructor training and doing a debriefing after; would be better with more interaction
+	* From Greg: would shared blogging help? No, not enough interaction
+	* From Karin: against 2 day because difficult for people from outside US, or whereever the event would be, cost for travel. Geographically and demographically limitiing. Also +1 on Karen's comment about blogging and interaction. Would be OK for one person to blog and then have that be the discussion piece for the book/journal club. Suggests that they do it for all the trainers regularly. Not just for people who are training. Would want to continue participating in an ongoing activity.
+	* From Rayna: also +1 on journal club; when she went through there were 2 meetings where everyone got together, and that was the best part. Liked that everyone from all geographies was a great way to meet and interact with the whole global community (some at 2am and some at 6am, and everyone committed was great). Journal club format is a good idea.
+	* from Anelda: People also mostly need time to grow into trainers which is easier to do over time and with discussion as mentioned by Karen and others; I already feel very concerned about having to teach now since I participated in my last instructor training in September...
+	* From Jason: likes 2 days because can be concentrated; wants to respond to what Karin says. Thinks there can be regional things going on, so if there are geographially distributed CarpentryCons, then this would work potentially that people could attend their regional meeting; maybe not now but in the future
+	* From Jonah: For people that were in mentorship, did it help prepare you to be an instructor trainer? Should that be a part of the pathway to becoming an instructor trainer?
+	* From Rayna: Was attending two debriefing sesssions per month, so she essentially felt 60 workshops, so felt like she had massive body of knowledge throught osmosis, so felt like she knew more about workshops, even though she had taught just 2 in the same time frame. Multiple perspectives. Doesn't know any other way to get that information than by hosting those discussion sessions. Could require that people participate in discussion sessions as a part of instructor training. 
+	* from Karin - can do two full days if remote is possible
+	* suggestion: require people to take part in mentoring sessions as part of trainer training (low-cost requirement)
+	* From Karen: doesn't want to push people too fast through instructor training, wants to properly prepare people, longer more interactive process
+		* the instructor training is what makes SWC / DC special; want to keep quality of the instructor training workshops
+	* From Tracy - important to have new trainers paired with experiened instructor. when in front of the class you feel who inexperienced you are on a tool that you only started using a few months ago. 
+	* From Tracy: Don't have the background in educational pedagogy to feel prepared to teach this content. Many +100s to this. 
+	* From Jason: need for instructor trainers partly driven by business needs of the Carpentries. Smaller group that we can demand more from, because of its importance. Everyone in the room agree to a core set of principles about what the brand is and what we do. Always going to be a smaller group here, so it can be more engaging/intensive.
+	* From Karin: Two issues. 1 is certifying new instructors and the other is educating those who are already qualified. 
+	* From Jonah: Looking at judo and how you develop people. Some people take 20 years, some take 2 years to get their black belt, but there's a structure for how people move through, and an ecosystem / environment that supports that is useful, opportunities for this training. Also have stage gates, where people meet certain objectives. Build the ecosystem and the system for recognizing that you've done enough. 
+	* From Rayna: Putting together this cumulative thing is good. But having a variety of different ways to get that 'green badge'. Multiple paths to this expertise. Multiple ways to get a similar badge. 

--- a/minutes/2017-03-23-business.md
+++ b/minutes/2017-03-23-business.md
@@ -1,0 +1,93 @@
+# Carpentry Instructor Trainers Group
+
+## Trainer Business Meeting  (Note time change outside of USA)
+- Thursday, March 23, 2017 UTC 22:00 (Erin)
+- Brisbane 8am FRIDAY, Melbourne 9am FRIDAY, Auckland 11am FRIDAY, San Francisco 3pm THURSDAY, Philadelphia 6pm THURSDAY
+- See this link for your local time: https://www.timeanddate.com/worldclock/fixedtime.html?iso=20170323T15&p1=224
+
+## Attending UTC 14:00 (Maneesha)  x = present
+- Maneesha Sane x
+- Aleks Nenadic x
+- Kari L. Jordan x
+- Jeff Oliver x
+- Rayna Harris x
+- Mateusz Kuzak x
+- Chris Hamm x
+- Christina Koch x
+
+## Attending UTC 22:00 (Erin)
+- Christina Koch x
+- Erin Becker x
+- Belinda Weaver x
+- Anelda van der Walt x
+- Ariel Rokem x
+- Naupaka Zimmerman x
+- Karen Word x
+
+## Apologies
+- Steve Crouch
+
+
+## Agenda
+
+## Introductions
+
+## Announcement about curriculum (Christina)
+- official maintiners. in the past it was Christina and Greg. Now its Christina and Erin. 
+- working on resolving old issues and cleaning the docket. new developments will be discussed at these meetings
+- quick fix - easy things that can be resolved with a pull request without further discussion
+- Erin and Cristina will give us an update on all the tags once they finalize the meaning
+- specific question from Anelda: with upcoming workshop, can shorten carpentries module (based on upcoming potential merger?)  Answer: should still cover same material, but if it takes less than an hour, that's okay.  
+
+## Scheduling training events (update for June-August)
+- new process, organizing schedule around trainer's calendars.  Saying "trainers are available at these dates" and have the partner sites sign up. 
+- everyone reported their availability here https://docs.google.com/spreadsheets/u/1/d/10qr987YT9qYi0NGO1sJhe3OHkIL70bbqtUbJNvhfC58/edit
+- Meesha has put together a tentative schedule in the same document above
+- Everyone has been assigned a partner and a few dates to choose from
+- note: Belinda is running a training in June that's not listed (June 19-20, Sydney)
+- workshops that have been pre-arranged are not necessarily on this calendar
+- **ACTION ITEM**: everyone discuss with your partner and chose a date. Let Maneesha know by Thursday March 30th. Then those times will be "confirmed." 
+- These dates will then be shared with the partner sites and they will be asked to sign up at least one month in advance. 
+- This seems to be working for people 
+- If you didn't sign up for a time in this time range, shadow an event in your time zone
+- Question: Are these online or in person: Answer. These will all be online training event. 
+- Moving forward, we will continue this process four times a year so that we always have a plan three months out. For non-summer months, the goal will be to offer 1 per time zone per month.
+- For the trainers who are not assigned a training during the three month period, they will be asked to help assist with planned trainings. 
+- Questions: How soon is too soon or too late for planning. Answer: The current planning schedule worked great for some. 90 day notice good for some.
+
+## Ensure all participants complete application form
+- Context: Track instructor trainees via an account in AMY.  This account is only created when people complete the training application form (link: https://amy.software-carpentry.org/forms/request_training/ )
+- Many people have not been completing the application form. This means we cannot track their progress and have to ask them for this information after the fact.  
+- Solution: The trainers should take 5 minute to ensure that everyone completes this during the training event. 
+- **Suggestion:** Add the workshop tag "YY-MM-DD-ttt-online" group ID to the welcome email so that everyone knows that they are part of a group and should use that 
+- **Suggestion:** Officially add this to the cirriculum if its not already there
+- Side issue: automatic response to the form says "we can't provide open training" which is confusing to people who are "applying" for a training that's already happening
+- V. Important to include the group name in the form!  This is what makes sure that people don't get the generic "open training" email
+- Potential future state: changing the form to make it choosing from options as opposed to free text entry
+- Suggest changes at: Github repo for AMY: https://github.com/swcarpentry/amy
+- Ariel: before, entered data using csv?  Can we still do that?  Answer: no, mostly because we'd like to keep lots of people from all entering data into the database
+- Belinda to provide some feedback to Erin on the automatic email that goes out
+
+## Process for recording trainee progress.  One badge.
+- we are moving from a two badge system to a one badge system.  One discussion, one contribution, one demo --> one badge
+Erin has changed all the documentation, if you see anything that didn't get changed, let her know.  
+- send list of who completed training, demo, discussion to checkout@carpentries.org.  Do not record anything in AMY.
+- What to do about people who didn't pass (didn't participate in discussion, didn't show up for session they signed up for)
+- For demo sessions: They should be allowed to come back and repeat the demo. 
+- One option is to give a second try, but the trainer can show discretion based on the learners attitute and preparation
+- Making the expectations more clear about what to do after the training could help minimize problems with incomplete checkout. Managing expectations is crucial.
+- Question: Are we talking about a rubric with a point/scale system or a pass fail. Answer: Pass Fail just for the demo. There is a github issue on this: https://github.com/swcarpentry/instructor-training/issues/394
+- Problem: very high attendance at discussion session does make it hard to get meaning discussion from participants. Answer: the mentoring committee has disucssed splitting up the group into two groups, but this is logistically challenging. Still working on an ideal system. Christina: in favor of elminating multiple checkouts, but want to make sure we have some future discussion about what might be different about teaching SWC/DC; instructors will probably self-select by the workshops they teach, but want to provide support for the ways that the teaching is different between the two
+
+## What do you need to be prepared before/during/after an event?
+- Maneesha is working on a detailed operations guide for all the things. 
+- **Creating a checklist**: Add your comments here! https://github.com/swcarpentry/instructor-training/issues/328
+- Comment: Issue on github regarding a google drive folder: https://github.com/swcarpentry/instructor-training/issues/405 this would be a great place to store slides so that we can share them and (if you want) to reuse them. should all be saved in an editable format, not pdfs
+- Comment: students want a better reading list. Greg will put together more detailed comments on the books we reccomend. Use PRs for the instructors guide to add your own favorites https://github.com/swcarpentry/instructor-training/blob/gh-pages/reference.md  --> should someone make an issue for this?  
+- Comment: would like a way to print all the lessons in 1 document rather than printing all separately. Answer: couldn't find a soultion to this. --> I (Christina) think Raniere wrote a script at one point to do this?  I seem to remember that too
+- Comment: Would like to know three things about the learners 1) DC/SWC famililarity 2) teaching experimence 3) motivation for training. SOlution. Maneesha is working to get a solution so that we know this information about the learnings a few weeks before the training so that this info can be shared with the instructors.
+- Comment: A guide on how to make slides would be useful. Solution: The carpentries will work on a template slide deck that will give consistency on style and accessibility. 
+- Tracking what experience people have, to make it easier to organize locally/regionally
+
+## Conlusion
+- Talk with your partner and get back to Maneesha with your dates for teaching by next Thursday 

--- a/minutes/2017-04-06-discussion.md
+++ b/minutes/2017-04-06-discussion.md
@@ -1,0 +1,73 @@
+# Carpentry Instructor Trainers Group
+Etherpad users are expected to follow our code of conduct: http://software-carpentry.org/conduct.html. This Etherpad will be archived and publicly available.
+
+## Trainer Discussion Meeting
+- Thursday, April 06, 2017 UTC 14:00 (Maneesha)
+  - San Francisco 7am , Philadelphia 10am , London 3pm , Oslo 4pm, Cape Town 4pm
+- Thursday, April 06, 2017 UTC 22:00 (Erin)
+  - Brisbane 8am FRIDAY, Melbourn 8am FRIDAY, Auckland 10 am FRIDAY, San Francisco 3pm THURSDAY, Philadelphia 6pm THURSDAY
+- LOCATION: https://bluejeans.com/u/erin.becker/
+
+## Attending UTC 14:00 (Maneesha)  x = present
+San Francisco 7am , Philadelphia 10am , London 3pm , Oslo 4pm, Cape Town 4pm
+See this link for your local time: https://www.timeanddate.com/worldclock/fixedtime.html?iso=20170406T07&p1=224
+- Maneesha Sane x
+- Martin Callaghan x
+- Kari L. Jordan x
+- Jeff Oliver x
+
+## Attending UTC 22:00 (Erin)
+Brisbane 8am FRIDAY, Melbourn 8am FRIDAY, Auckland 10 am FRIDAY, San Francisco 3pm THURSDAY, Philadelphia 6pm THURSDAY
+See this link for your local time: https://www.timeanddate.com/worldclock/fixedtime.html?iso=20170406T15&p1=224
+- Rayna Haris
+- Erin Becker
+- Sue McClatchy
+- Mark Laufersweiler 
+- Naupaka Zimmerman
+- Tim Dennis
+- Jonah Duckles
+- Greg Wilson
+- Tracy Teal
+
+
+# Agenda 
+##  1st meeting
+- Martin, Jeff, Maneesha - all new trainers, no specific questions
+- Kari - two upcoming in person trainings in South Africa (with Anelda and Aleksandra) and Florida (solo)
+- South Africa team is still deciding who leads what module.  Maneesha, Martin, and Jeff all suggested that Kari take on the modules she's least comforatable with for the South Africa training, when she'll have support, in order to be ready to teach on her own in Florida
+
+- Question:
+    - Anything additional instructor trainers should be doing before/during/after traning event?
+    - Maneesha: make sure participants complete applciation.  Without it we have no way of tracking their progress.  Trainers should email names/emails of people who completed and didn't complete training to checkout@carpentries.org.  All this will soon be in an operations guide.
+- Maneesha asked Martin about recent training cohort at Leeds.  One person did not complete, everyone else is working on checkout and will be teaching in the next few months.    
+
+## 2nd meeting
+
+- Sue taught twice recently - once with Erin and Rayna and once with Tracy and Rayna. 
+  - First training was online with Rayna and Erin, was her first instructor training event. Was surprisingly easy, used to teaching remotely/online. Made it interactive by talking for ~5 minutes and then doing something with the audience. Was NIH + Great Plains Network/Greater Western Library Alliance. 
+  - Then taught in Puerto Rico. Trainees grasp of English wasn't great, but were able to manage. The group was very motivated to improve their own teaching and build a strong data-literate community. Most had been observed teaching, which is not the case with instructors in the States. Had real community focus. Sue will be following up with them for certification. PR training happened at same time as 36-hour replicathon. UPR group was all PIs. Very enthusatic about going on to teach workshops (which isn't always the case with senior faculty). Started with a 45 minute talk about why Data Carpentry & Software Carpentry are awesome, the mission, their goals, and their accomplishments. 
+  - Sue and Erin - some conversations about prioritizing training new Trainers who are native Spanish speakers and can help grow the Carpentry community in Spanish speaking countries. Will need to discuss how to diversify our Trainer group as we work on putting together the application process for Juneish.
+- Greg - has taught a few one-day events for people working with non-academic groups. Wants to know what other experience folks have had with this type of training experience.
+- Advice for teaching in person versus online?
+  - in person coffee breaks and meals gives the change to build repor
+  - in person its easy to circulate the rooms and be a helper
+  - for online be sure to always engourage etherpad answers. participation increases when you explicity write their nename in the etherpad 
+  - time keeping is easier in person than online
+- Thoughts on Introductions
+  - people work together better when you give them a good instroduction exercies, like the one that Tracy uses asking them to say your name, your research in 3 works, something you are proud of making. This will be especially important for online courses
+  - for very small workshops with only 15 people, you could go around the room and do introduction so that everyone knows everyone's names
+- Q? Is there a guide for how to use the Etherpad.
+  - A. recently we've added instructions for each challenge/exercise how to use it with the Etherpad.
+- Thoughts on co-teaching. having both instructors present has many benifits. its gives continuity, allows for both instructors to observe each other, gives you a helper, demonstrates that we utilize the teaching practices that we recommend.
+- Q? advice for teaching advanced undergrads? use pull request for homework
+  - A. great idea. Jenny Bryan and maybe Ethan might do it this way. Its a head ache at first but awesome later on. Its great because it becomes second nature for the students
+  - A. giving them an exercise and show them what you expect their pull request to look like
+- Brief conversation about virtual machines for teaching including pros and cons.
+- **Advice for new trainers:**
+  - Some people can see advice regarding teaching as an attach on there style/expertise. However, in these events, people are there because they WANT to be better teachers
+  - Teaching with just the notes but not the background expertise is challenging at first. 
+  - Your introduction is very important. Be sure to say why you have the experience to teach instructor training, not just as a coder.
+  - Enthusiasm goes a long way
+  - Have them write learner profiles so that you know what they are thinking about teaching in the future
+  - Have them pick a live coding lesson before they go home on day 1
+  - Warm them that they will love the video recording by the end of it. 

--- a/minutes/2017-04-27-business.md
+++ b/minutes/2017-04-27-business.md
@@ -1,0 +1,126 @@
+# Trainer Business Meeting
+
+## Attending UTC 14:00 (Maneesha) 
+San Francisco 7am , Philadelphia 10am , London 3pm , Oslo 4pm, Cape Town 4pm
+See this link for your local time: https://www.timeanddate.com/worldclock/fixedtime.html?iso=20170406T07&p1=224
+- Rayna Harris
+- Maneesha Sane
+- Jason Williams
+- Karin Lagesen
+- Sue McClatchy
+- Martin Callaghan
+- Aleksandra Nenadic
+
+(Sorry, I forgot to ask someone to take notes. I've added in what I can remember from this morning's discussion.  Anyone else should feel free to add in any other comments.  -Maneesha)
+
+
+## Attending UTC 22:00 (Erin)
+Brisbane 8am FRIDAY, Melbourn 8am FRIDAY, Auckland 10 am FRIDAY, San Francisco 3pm THURSDAY, Philadelphia 6pm THURSDAY
+See this link for your local time: https://www.timeanddate.com/worldclock/fixedtime.html?iso=20170406T15&p1=224
+- Christina Koch
+- Maneesha Sane (for first 30 mins only)
+- Belinda Weaver (first 30 mins only)
+- Jeff Oliver
+- Mark Laufersweiler
+- Karen Word
+- Naupaka Zimmerman
+- Jonah Duckles
+- Erin Becker
+- Tracy Teal
+- Tim Dennis
+
+## Apologies
+- Lex Nederbragt
+
+# Agenda
+
+- Training calendar for June - August 2017
+- See confirmed schedule here: https://docs.google.com/spreadsheets/d/10qr987YT9qYi0NGO1sJhe3OHkIL70bbqtUbJNvhfC58/edit#gid=1698063111
+- New trainees should shadow these events
+- This document is shared with new partners, and they have a chance to sign up for training slots
+- Q from Erin: at what point would we know what spaces are "unbooked" so we could possibly use them for open training?
+- Times become unavailable a month out to partners --> maybe try this for June - Aug
+- Could also just "reserve" times in the calendar up front --> will do with the Sept - Dec calendar
+- Q from Belinda: no specific S. Africa time right now -- are they in the same time zone category as UK or Europe?
+- Upcoming events are covered for now, may schedule these more on demand
+
+- Training calendar for Sept - December 2017
+- Maneesha would like to do the same thing we did to set up the Jun-Aug calendar.  Will send out a new Google doc & ask for everyone's availabilty by Friday, May 19.  Comments/suggestions on the *process*? (We will discuss the actual time commitment from each of you below)
+- Goal is to have one training per month (Sept, Oct, Nov, Dec) in each of these six time zones  (US Pacitic, Mountain, Central, Eastern, UK & Eur)  (6*4 = 24 trainings total)
+
+# NOTES  
+- Question from Maneesha:  how far in advance can you schedule things?  How soon is too soon?  2-3 months in advance is generally good -- some people may not know about Sept-Dec until August.
+  - In the future, as trainer pool increases -- will this scheduling system scale?
+  - Maneesha will be asking for trainer feedback.  :)
+- Explicit Trainer Agreement
+  - How may training events are you able to commit to?  Most people say 2-3 per year
+  - How should this document (once finalized) be shared?  Not as an official contract - more as a way to share expectations before new trainers come on board
+  - Another model of offering training disucssed:  Trainers commit to teaching 2-3 modules, becoming experts in those modules.  They would then make themselves available  for a couple of hours every month rather than 2 full days twice a year.  Need to explore this more as new cohort of trainers comes on board. How would this affect continuity and the expereince for the learners?  Would this feel disruptive to the learners? 
+- GitHub issue https://github.com/swcarpentry/instructor-training/issues/349
+- Karin's GoogleDoc:  https://docs.google.com/document/d/1LWxy_hs3FRm3K2Q6eZti4FXqsbl574f5aCXwbWJ5adk/edit?usp=sharing
+- Erin's Google Doc: https://docs.google.com/document/d/14Zi_W9uk1wua2v3zy8um6oMCnvO41Qfo1KwStCA-hos/edit
+- Much of Karin's document is about our motivation, philosophy, etc.  Erin's document is about the practical expectations.  Underlying goals still seem to be the same.  We can work on merging things.
+- Discussion: How long can an instructor be "inactive" before losing status?  Most people agreed a semester/few months is OK; 6-12 months or longer and they should have to do some kind of re-entry program
+- Q from Belinda: could demos + discussions be interchangeable?
+  - Erin: demos can only be done by trainers, but if we eventually have enough trainers, could cover discussions too
+  - Jonah: pushing people interested in becoming trainers to discussion sessions, as a "starting point"
+- Q from Belinda: running teaching demos for people you've taught?
+  - Erin: put a notice in etherpad for trainees to sign up with someone they didn't learn from
+  - Christina/Tracy: can't always make two meetings a month; is there a way to build in flexibility?  Suggest/require reading the notes?  
+- Food for thought: How to strike a balance between people's busy schedules and building community via meeting once or twice a month? 
+
+What to report
+- Number of training events in the past month and where, number of attendees at each event
+- Changes to checkout policies
+- Number of trainees expected to checkout in current 90-day checkout window
+- Significant changes to curriculum (we could see if it's having an impact on how prepared people seem)
+- Anything particularly awesome - celebrate successes!
+- Any particular consistent issues that might impact people going through mentoring
+- Number of people going through teaching demos (and what lessons are popular?)
+
+What info to get from mentoring
+- How many people are attending discussion sessions as part of their checkout
+- Are there any no-shows? (maybe % of no-shows)
+- What instructor trainings are people checking out from --> This will be hard for us to track and is otherwise in AMY
+- What kinds of questions do new instructors have (maybe those are things we could cover during instructor training)+1
+- what is acceptable particiaption to have it count for the instructor checkout as part of the reporting
+ie. showed up but did not interact
+- Anything particularly awesome - celebrate successes!
+- Distribution of interest in DC vs SWC vs LC (or all three?)
+
+Action
+- Tracy to put together Google docs with template questions and circulate to mentoring and trainers for comments. We can use these templated documents for reporting out from the meetings
+
+- How are these data being used? (annual reports, preparation for future events)
+- Who are the consumers of these data? Mentors and Trainers (respectively)
+
+- Mentoring committee communications
+  - Is anyone interested in being a liaison between the mentoring committee + this group?  Main duties would be to communicate relevant changes in the checkout process to the mentoring committee; and bring questions from the mentoring committee back to this group.  If you're interested, put your name down.  
+  - Related: for trainers who have recently hosted discussion sessions -- how engaged are the trainees?  
+  - To bring back to the subcommittee: how many people have been recently trained (that we should be expecting through the sessions)?
+
+- No volunteers from the first group
+- Belinda would be willing to do this
+
+- Tracy's suggestion: create a standard form / report of information to send back and forth.  See suggestions for material above.
+- Coordinate with Marian/Jamie on the mentoring side, and Erin/Belinda/Christina on the trainer side? 
+
+- Carpentry checkout and Library Carpentry
+  - You may see a few folks checking out using Library Carpentry materials in the next month or so. This does not reflect a change in our checkout policy, as these folks were single-case exceptions. In general, new instructors must certify using SWC or DC materials. If there are any questions about specific individuals, please contact Erin or Maneesha.
+  - One of the recommendations/suggestions for LC instructors is to be a SWC/DC instructor.  
+
+- Providing feedback from instructor trainers about instructor training events
+  - Would it be useful to have a form that we fill out about how things went +1 to this!
+  - Yes.  The discussion sessions are a way to share feedback about how things went.  An official form to put this together would be useful
+
+- **Template blog post** Erin put together a template blog post set of questions (feedback for internal circulation would be more than this) https://docs.google.com/document/d/1iJROM0QynqzCKFh2hEkjUYWsEttDTPbrFZz-xcTwbzo/edit
+
+- Possibilities: 
+    - half day hackathon for instructor training curriculum development
+    - way to capture notes while they're fresh
+    - incorporating both of these into the lesson publication cycle
+    - using hypothes.is to annotate the lessons as we teach
+
+## Non Vebal updates
+- Rayna, Sue, and Tracy published a blog post about the recent instructor training event at the University of Puerto Rico! http://www.datacarpentry.org/blog/UPRtraining/
+CK:  +1! Very exciting

--- a/minutes/2017-05-04-discussion.md
+++ b/minutes/2017-05-04-discussion.md
@@ -1,0 +1,81 @@
+# Trainer Discussion Meeting
+- LOCATION: https://bluejeans.com/u/erin.becker/
+- Etherpad users are expected to follow our code of conduct: http://software-carpentry.org/conduct.html
+
+## Attending UTC 14:00 (Maneesha)  x = present
+San Francisco 7am , Philadelphia 10am , London 3pm , Oslo 4pm, Cape Town 4pm. 
+See this link for your local time: https://www.timeanddate.com/worldclock/fixedtime.html?iso=20170406T07&p1=224
+- Chris Hamm x
+- Jason Williams x
+- Mateusz Kuzak x
+- Neal Davis x
+- Karin Lagesen x 
+- Maneesha Sane x
+
+notes:
+- discussion session is about past and upcoming events as oposed to business meeting
+- Maneesha is teaching face to face tomorrow Federal Reserve Board, Washincton DC (first instructor training) Karin Word started yesterday this workshop
+- Jason asked about rubric for demo sessions, the respective issues are:
+        - https://github.com/swcarpentry/instructor-training/issues/394
+        - https://github.com/swcarpentry/instructor-training/pull/433
+        - https://github.com/swcarpentry/instructor-training/blob/45fd642130a3d50d7639dff475109d3f6dc4562c/files/teaching-demo-rubric.md
+- Maneesha will check with Erin what is the status of this.
+- One training just finish in South Africa, Stanford, Florida
+- More on Federal reserve Board workshp: they did SWC and DC workshops on the same week,
+- all new hires in Fed have to go through SWC and DC workshop, they are a member
+- this workshop is for people coming from the banks
+- 6-8 trainings a year
+- Ending the motivation lesson with demotivation exercise is awkward
+- Chris taught both new hires and board, and the new hires where super enthusiastic
+- Jason: what is more interesting for this group? it would be great if we learn more about it, so that we keep our customers happy, and capture feedback
+- Karin: teaching practicing module - Karin present it with stickies, walks around shows standing up (literaly show 10 recommends for teaching)
+- Mateusz: could we subscribe people at the end of the workshop, how many sessions would we need to do that
+- todo: Mateusz is going to do some number crunching on how many session we would need, and send an email to the trainers list with a suggestion
+- online slots:
+  - June 1-2 canceled
+  - end of June Maneesha with Rayna
+  - one in person training with Chris
+- Chris may train in person with people in the area
+- Karin: instructor training in Oslo, in person training are there any partners near by to send people to the training
+
+
+## Attending UTC 22:00 (Erin)
+Brisbane 8am FRIDAY, Melbourn 8am FRIDAY, Auckland 10 am FRIDAY, San Francisco 3pm THURSDAY, Philadelphia 6pm THURSDAY. 
+See this link for your local time: https://www.timeanddate.com/worldclock/fixedtime.html?iso=20170406T15&p1=224
+- Erin Becker
+- Christina Koch
+- Rayna Harris
+
+# notes
+- Recent/upcoming trainings
+  - Erin teaching two weeks from now at Stanford (in-person)
+  - Christina just taught online with Tim
+- EB: Now having a Google Drive available for storing notes. start collecting group knowledge!
+- Story bank
+  - RH: Rayna tried to use an example she really liked from Erin, and it didn't work
+  - RH: Hard to have stories that go across places, but so valuable in having good stories / examples / analogies
+  - CK: remembers Karin asking for more stories, but it's hard to capture/categorize general good stories vs personal stories (only you can do) vs specific stories
+  - EB: Need to capture the variations (adding material) that people do as well.
+- Big picture
+  - Instructors should know the imporatance of modeling failure
+  - More important to teach what learners are learning, but not all the ideas (learner-centered teaching)
+  - CK: What's best for the learners, not what I want to teach
+  - CK: Opening the door + giving a map, rather than walking people all the way to the destination
+  - EB: So ingrained to "cover content x"
+  - Creating a welcoming environment
+- Lesson turnover/involvement
+  - RH: Lessons go stale when the original creators stop teaching and contributing back
+  - RH: Is there a way for communities to have little forks of curriculum that they can "own"
+  - EB: Way to do more specific lesson discussions?  Not enough resources now, but... Would that be fracturing?
+  - RH: But it also builds community, 
+  - RH: What about having a weekly discussion on lesson?
+  - CK: Need to split the discussion sessions into more channels --> de-brief, lesson-specific, workshop-logistics
+  - RH: If you set the time + advertise, people will show up!  :)
+  - EB: Bring some of these ideas to the new community manager
+  - RH: Definitely, have the new person connect w/ *many* of our communities (around the world, internal, etc.)
+- Upcoming trainers
+  - fluent/native Spanish speaker
+  - HPC? 
+  - Librarians?
+  - Social science, ed, business
+  - "class" diversity -- having someone from a small institution

--- a/minutes/2017-05-24-business.md
+++ b/minutes/2017-05-24-business.md
@@ -1,0 +1,159 @@
+# Trainer Business Meeting
+ 
+## Attending UTC 14:00 (Maneesha)  x = present
+San Francisco 7am , Philadelphia 10am , London 3pm , Oslo 4pm, Cape Town 4pm
+- Erin Becker - x
+- Kari L. Jordan - x
+- Mateusz Kuzak - x
+- Christina Koch- x
+- Belinda Weaver - x
+- Maneesha Sane- x
+- Jason Williams - x
+- Mark Laufersweiler -x 
+- Chris Hamm- x
+- Anelda vd Walt -x
+ 
+## Attending UTC 22:00 (Erin)
+Brisbane 8am FRIDAY, Melbourn 8am FRIDAY, Auckland 10 am FRIDAY, San Francisco 3pm THURSDAY, Philadelphia 6pm THURSDAY
+- Erin Becker - X
+- Jeff Oliver - X
+- Rayna Harris - X
+- Karin Lagesen - X
+- Tracy Teal -X
+- Karen Word - X
+- Jonah Duckles - X
+- Tim Dennis - X
+- Naupaka Zimmerman - X
+  
+# Agenda
+ 
+If you won't be able to attend the meetings but would still like to contribute to the discussion and vote, please send your comments and vote to the Trainers list.
+ 
+- Update on plan moving forward for open instructor training
+- Vote on Instructor Trainer application: https://docs.google.com/forms/d/1ptwIDsLQPZiagRX7OSw642YV6MaqCYSw5qIHb7NtZqg/edit
+  - +9 and -0 from first session
+  - +1 in general - Karin is wondering about the section about Spanish/tribal etc.
+  - Updated question: is this an effort going on at the moment? In that case, all this could be solved by adding "At this time, we are specifically working"... that also sends the message that we could be targeting a different group next time (which is what I suspect is Erin's intention :))
+  - That section is now updated to "We are specifically working to expand the Carpentries community in Latin America and across diverse institutional types." Looks good! Could it be updated to 'Latin America and Africa' since there is a lot of activity in Africa right now and we want to support that?
+  - Instead of just Spanish could it also be 'Other languages you're fluent in' then be able to list them? And then maybe 'Associations with universities serving underserved communities'. Since we'll likely keep these applicatons around for potentially another round, the information would be useful if we change priorities and also relevant internationally. 
+  - +9 and -0 from second session
+ 
+- Vote on Instructor Trainer agreement: https://docs.google.com/document/d/12E4Zw7q61plmSHshK7ZEl1YsQNhJ_4kYVfyynElbTyI/edit
+- Update on plan for instructor training curriculum lesson release in August
+  - +10 and -0 from first session
+  - +9 and -0 from second session
+- Outline: https://docs.google.com/document/d/1t2W8PKu78KtTX92qdhqclYGljAbLiWfhza7qH6s1088/edit (please add comments to doc or send comments to Erin (ebecker@carpentries.org) by June 5th)
+- Issue Bonanza: July 13-14 
+- Bug BBQ: August 3-4
+- Publish! August 11
+ 
+ 
+Notes: 
+ 
+### Scheduling Instructor Training for Sept - early December (fall for northern hemisphere - maybe better to refer to mnths rather than seaon?) Good catch!  Thanks for pointing that out.
+    - Maneesha to send out a scheduling spreadsheet soon (same as last time) to fill out for Sept - early Decemberish
+    I'd like to have at least a couple on the calendar for early December.  That's when classes end in the US and people may want to do something then.  Definitely not past mid-December. -maneesha
+    - Goal is to get one training slot available per major time zone per month
+    
+### Open Instructor training
+    - have clearance to process backlog of applications for open instructor training (~350 applications)
+    - thanks to Belinda, Mateusz and Jason for helping go through these!
+    - sorted by time zone, being reviewed in that grouping
+    - planning 7 events, will take up to a year to get through the backlog
+    - Maneesha + Erin will coordinate scheduling for these 7 events; may use "unused" training slots for Americas/Europe, will need other arrangements for Africa/Asia
+    - (Belinda to be in S. Africa in October, could help do a training there)
+    - Could also break up training into 4 half-days if it's hard to find good 8 hour blocks, or split training in half so first half is done by one person + second by another
+    - New places!
+      - Asia: India, Bangladesh, Nepal, Hong Kong, Singapore, China
+      - Africa: Ghana, Uganda, Kenya, Ethiopia, S. Africa, DRC
+    - Karin - we have a deadline for partners to sign up until a month before. Is it correct that we backfill only after that month?
+    - Erin- yes, that's how we're planning to handl events that fall into time zones already plans for partners. We probably won't have slots that will open up for groups in Asia  so we'll work on getting trainers for those.
+    - Rayna - assuming the 1-month time frame is enough time to prepare... should we have a longer deadline? Is that enough?
+    - Erin - were going through applications now so we have a list of everyone in each time zone. Because we don't have to set up physical rooms and we have a list of trainers, we think it will work! 
+
+### Instructor Trainer Application
+     - Application for next cohort of trainers (9-10) people
+     - Feedback sent by email, awaiting any final concerns or suggestions
+     - Rubric forthcoming
+     - Vote on application
+     - Move forward with opening applications; will publish/advertise as widely as possible
+       - Karin: this seems somewhat US centric so suggest we add "in this round" to clarify that this will change. 
+       - Erin - yes this is something that will change
+       - Tracy - thinking of this as a more general application, given that we're going to keep this on file, do we only want to have this information or do we want to be thinking about creating something that we might continue to use. Maybe we should put Africa on here? We don't want people to feel like their community is being excluded from being targeted for expansion. So would prefer a broader version, but we could go either way.
+       - Erin - have added Africa to that question... do we want to add more than English -- e.g. French?
+       - Tracy - is there a downside to asking "which languages do you speak"?
+       - Rayna-  searchability. Maybe we could do both?
+       - Erin - basically what we're looking for here is permission to go ahead with the application and we can fine-tune language later... move to a vote ok?
+     - vote +9/-0
+
+### Instructor Trainer Agreement
+    - Not something you would officially "sign", more of an informal agreement
+    - Mateusz: are there enough demo sessions for everyone to do one a month?
+         Erin: added language to "average" one a month so you could clump them together
+    - Belinda: also challenging to sign up for demos if you've trained a lot of people of recently and shouldn't be checking them out (as their trainer)
+         Erin: In general, try to avoid checking out people we've trained, but if it happens occasionally, that's probably okay
+    - Maneesha: add something about providing feedback about how training's went
+    - Notice the final section -- you can take a break and come back, but while inactive, won't vote on trainer decisions
+    - Chris / Anelda: challenge of things being added, feeling guilty when there are things you can't do (because we all have limited time!)
+        Erin: change monthly demo suggestion to quarterly
+        Maneesha: will have a lot more partners soon // Erin: will also have more trainers! 
+        Mark: Maybe think of it more as doing "one thing" a month -- a demo or a discussion or a 2-day training event each counts as one activity. 
+    - Related question: when do you become a trainer?
+       Erin: In the past, you become "fully certified" when you taught your first workshop; would be more in favor once you complete the "book club" portion of the trainer training
+       Maneesha: with more regularly scheduled training events, maybe include observation as one of the steps for certification
+       Jason: complete book club + demonstrate that you have some familiarity with this knowledge.  Can be easy to fall away, want to enforce standards. 
+       For people where trainer status matters for work, would an actual certificate be useful?  --> Yes! For professional and personal happiness.  :)
+       Jonah - How do we track active/inactive? How do we turn people off when they can't make the commitment?
+       Erin - basially I'm aware of who's doing what and if people are not active I can get in touch with them and see if that's intentional or if they just need a reminder. Happy to take this on.
+       Karin- thought on curriculum. We as an organization assume that instructors become instructors because they've been trained by our curriculum, but we have no explicit statement of this fact. 
+       Erin - is this a concern? Putting in a provision like this restricts people from trying out new modules and playing with new ideas. Worried about creating problems.
+       Naupaka - Even when we ask people to use the curriculum it's still pretty flexible. Is a high level of guidance re curriculum goals too restrictive?
+       Erin - we're thinking about rearranging the instructor training curriculum into modules, and what we're teaching are those things. It could be that we're talking about including those portions of the curriculum. I don't want to put something in our agreement right now because we don't have that structure in our curriculum and that kind of anticipates further action. I don't see this as a concern, where current instructors are likely to veer off the deep end with curriculum. Not strongly in favor and might send the wrong message. 
+       Rayna - If you think about the end from the perspective of the student who has to miss "a whole day" or "3 hours" having some iind of requirement about what a student must fulfill can provide a ready response to those issues.Loosely defined enough to allow for curricular expansion and  enough structure to make explicit requirements on both ends, both insturctor and student agreeing to a list of minimal required lessons.
+       Vote: +9/-0
+
+###Instructor Training Curriculum
+    - Thinking about next lesson release, and what adjustments we can make to the curriculum for that release
+    - Mostly a rearrangement; some material deleted (based on survey that was sent around); some things added as well
+    - Maneesha: table format is nice! Could be good to have a table like this in our published materials. 
+    - Jason: how are we collecting feedback from the trainees at this level in order to shape materials?  
+        - Erin: currently have a survey that goes out to trainees, need to do some more analysis // challenge of limited feedback, can evaluate efficacy of what is actually there
+        - What do with with sticky notes? --> at the moment, not much.  :P
+        - Planning to implement pre-workshop survey as well. 
+    - Timeline: 
+        - review material in June --> please leave comments in the document!  This is still the start of this process + we want your feedback.  
+        - In end of June / early July putting togethe reorganized curriculum IN A FORK.  ;)
+        - Issue Bonanza/Bug BBQ later in the summer to do final polishing
+        - Feedback wanted by *June 5*
+        - Karin - what do we do when we have people coming to the workshop who haven't been to a SWC/DC workshop? 
+        - Erin - that happened already. We don't have the carpentries modules until day 2, that's one basis for the Carpentries intro module that introduces people without getting into the weeds. 
+        - Karin - are we keeping that?
+        - Erin - yes. This balances giving an orientation without having to spend the first 2 hours explaining policy. That's demotivating!
+        - Rayna - Is there anyway that checkout can be moved from supplementary sometimes-hard-to-find thing to being Episode 24?
+        - Erin - what I've been doing is teaching the checkout extra episode as the afternoon wrapup. At stanford we didn't use it as a module. Please enter that as a comment on the document
+        
+### Bonus: 
+- Kari's training at University of FL
+    - Group was very interested in pedagogy + creating inclusive environments, lots of good discussions
+    - Lots of post-docs + faculty, may do checkouts later in the summer
+- Erin/Karen @ Stanford
+    - Lots of librarians
+    - Very into the pedagogy. 
+-  Tim/Belinda's library carpentry went well! https://software-carpentry.org/blog/2017/05/lc-Portland-Boston.html
+ 
+ 
+ 
+## Summary Email
+ 
+Hi everyone,
+Thanks to all who attended for a great set of Business meetings today! We had great turnout (18 Trainers across the two meetings) and a really productive set of discussions.We voted to move forward with opening up applications for joining the Trainers group using [this application](https://docs.google.com/forms/d/1ptwIDsLQPZiagRX7OSw642YV6MaqCYSw5qIHb7NtZqg/edit). We also voted on implementing an agreement for folks serving in the Trainer's group to help clarify expectations. 
+You can find the agreement [here](https://docs.google.com/document/d/12E4Zw7q61plmSHshK7ZEl1YsQNhJ_4kYVfyynElbTyI/edit). 
+Both passed unanimously after a productive discussion and well-considered modifications being proposed by the group. Thank you all for your attention to detail! 
+Based on our conversations, we'll also be moving forward with reorganization of the instructor training curriculum in preparation for our next lesson release in August. You can find the new outline [here](https://docs.google.com/document/d/1t2W8PKu78KtTX92qdhqclYGljAbLiWfhza7qH6s1088/edit). Please add comments before June 5th. After that point Christina and I will start a new fork and begin the rearranging process. You're welcome (of course!) to get involved with posting issues and PRs in that fork right away, but we'll also be having dedicated Issue Bonanza and Bug BBQ days prior to the release. The dates for those are: 
+- Issue Bonanza: July 13-14 
+- Bug BBQ: August 3-4 
+- Publish! August 11
+We also updated on the process moving forward with open instructor training events over the next year. Thanks again to all who are helping go through the 350 current applications. I'll be in touch about next steps in mid-June.
+Thanks again to everyone for a great meeting. Looking forward to seeing you all again soon.
+Best,
+Erin

--- a/minutes/2017-06-01-discussion.md
+++ b/minutes/2017-06-01-discussion.md
@@ -1,0 +1,79 @@
+# Trainer Discussion Meeting  Thursday June 1
+
+## Attending UTC 14:00 (Maneesha)  x = present
+San Francisco 7am , Philadelphia 10am , London 3pm , Oslo 4pm, Cape Town 4pm
+See this link for your local time: https://www.timeanddate.com/worldclock/fixedtime.html?iso=20170406T07&p1=224
+
+- X Maneesha Sane
+- X Kari L. Jordan 
+- X Anelda van der Walt
+- X Sue McClatchy
+- X Karen Word
+
+## Attending UTC 22:00 (Erin)
+Brisbane 8am FRIDAY, Melbourn 8am FRIDAY, Auckland 10 am FRIDAY, San Francisco 3pm THURSDAY, Philadelphia 6pm THURSDAY
+See this link for your local time: https://www.timeanddate.com/worldclock/fixedtime.html?iso=20170406T15&p1=224
+
+- X Rayna Harris
+- X Erin Becker
+- X Christina Koch
+
+## Apologies
+- Mark Laufersweiler (ton ravel: Conference Attending OSF workshop) 
+
+# Agenda
+
+## Discussion of past training events
+
+- 30 April - 2 May, South Africa (in person): Kari Jordan, Anelda van der Walt, Aleksandra Pawlik
+    - Kari:  1st time doing instructor training.  Good to work alongside Anelda & Aleksandra, split up load.
+    - Anelda invited current instructors to join and share their experiences with new instructors
+    - Challenges not related to teaching, participants, etc.  Etherpad crashed, spotty wifi.
+    - As expected people may have been a little tired at the end (2.5 days)
+    - Anelda: Did training in 2016, only 11/23 checked out, brought them all back together to see how the experience was.  Connected them with the new instructor training
+    - Large group: 28/30 came (1 person in and out; 1 canceled last minute)
+    - PR/discussion participation has already started
+Having experienced instructors helped a lot to share their own experiences
+    - Experienced instructors have been voluntarily mentoring new ones, walking them through all steps of running a workshop
+    - Kari was great!  So interactive.  Every lesson became an opportunity for people to talk to each other.
+    - Aleksandra did the 2016 training, coincidentally got to come back for 2017.  Good experience for her and for instructors to see her return
+    - Very positive, supportive environment.   
+Shared feedback on giant white paper on wall with new and old instructors along with trainers
+    - Karen: How do the community building efforts work? Anelda: Things like open science, reproducible research isn't widely talked about.  After a two day workshop you may not be able to adopt what we've taught.  Running workshop is connected with buiding a community.  Doing study groups sponsored by Mozilla Science Lab.  Running since 2015 with some ups and downs.  New organizer got things going again.  Uni. of Venda created a Whats App group to communicate and share resources.  
+
+- Buidling community in Latin America.  In Mexico, taught SWC workshop in January.  Some will be joining instructor training in August.  Issues: Economic problems 
+    - Put in touch with Andy South who is running workshops in Latin America
+    - And Hugh Shanahan and team in terms of CODATA-RDA workshop
+
+- May 4-5, Federal Reserve Board (in person): Karen and Maneesha
+    -    Karen: Everyone there was very excited and energetic. Also very exhausted - instructor training was part of "Week of Carpentries" --- SWC and DC workshops earlier in the week. Turned everything into an activity to keep fatigue level low
+    - Never worked with web-based contents - used to slides
+    - Federal Reserve Bank have been taking a lead on getting Carpentries aboard over the past 2 years
+    - Maneesha: The week was very long and would like to think about how to do that differently
+    - People were traveling from all over and had to make best use of the opportunity when everyone was together
+    - They are taking a lead on developing and economics-based Data Carpentry
+
+- Question about slides: Maneesha thinks about this a lot - do people share the lesson material - scroll through e.g. or how do people do this?
+    - KARI: If there's an exercise - put it in the etherpad. If there's a diagramme, open all the diagrammes at the begining of the day in various browser tabs and just show that when the time is ready
+
+- May 4-5, Library Carpentry (in person): Belinda
+no update
+
+- May 18-19, Stanford (in person): Erin and Karen
+    - Karen: Very different group of people from the Federal Reserve Bank.
+    - Nice to see how Erin did the training
+    - Participants asked lots of questions and challenged the materials etc in awesome ways
+    - Erin turned a lot of the conversations into opportunities to get people's Pull Requests on lessons done in class. It showed people how easy it was to do the PRs 
+    - Nice to run the two workshops back-to-back to compare.
+    - Challenges- had to work hard to get buy-in from one of the people. Remember to ask lots of questions to help the person understand what about the material or concept is hard to understand.
+
+- May 22-23, University of Florida (in person): Kari
+    - Kari: Challenge was around mental models. There were still people struggling with the concept when they gave feedback on the stickies. More examples for mental models may help. Kari gave extra examples during the section.
+    - Creating an inclusive environment - should create more strategies and opportunities to do this. Should recruit and retain members of under-represented groups. They were very interested in that.
+    - 1 Faculty member and postdocs and postgrads. Very interested in the pedagogy. Thai women were very excited to see a woman trainer. 
+    - Kari was the only trainer, Francois helped but isn't qualified yet.
+    
+## Upcoming training events
+- June 26-27, Space Telescope Institute (on line): Maneesha, Rayna, and Jeff
+- Additional July-August Trainings
+https://docs.google.com/spreadsheets/d/10qr987YT9qYi0NGO1sJhe3OHkIL70bbqtUbJNvhfC58/edit#gid=1698063111

--- a/minutes/2017-07-06-discussion.md
+++ b/minutes/2017-07-06-discussion.md
@@ -1,0 +1,129 @@
+# Thursday, July 6, 2017
+
+## Attending UTC 14:00 (Maneesha)  
+San Francisco 7am , Philadelphia 10am , London 3pm , Oslo 4pm, Cape Town 4pm
+
+- Maneesha Sane
+- Kari L. Jordan
+- Lex Nederbragt
+- Mateusz Kuzak
+- François Michonneau
+- Greg Wilson
+- Chris Hamm
+- Mark Laufersweiler 
+- Paula Andrea Martinez 
+
+## Attending UTC 22:00 (Erin)
+Brisbane 8am FRIDAY, Melbourn 8am FRIDAY, Auckland 10 am FRIDAY, San Francisco 3pm THURSDAY, Philadelphia 6pm THURSDAY
+
+- Danielle Quinn
+- Amy Hodge
+- Belinda Weaver
+- Jonah Duckles
+- Erin Becker
+- John Simpson
+
+## Apologies
+- Anelda van der Walt 
+- Rayna Harris
+
+# Agenda
+
+**REMINDER:**  Please be sure to note your Sep-Dec 2017 availabiltiy if you have not already done so (Martin Callaghan, Karen Cranston, Neal Davis, Tim Dennis, Karin Lagesen, Aleksandra Pawlik, Fiona Tweedie, Alastair Walsh, Jason Williams, Greg Wilson)
+
+## Recent training events:
+    
+### Macquarie, Austrailia, June 19-20
+Trainer: Belinda and Jonah
+- Had 18 attendees. 15 from Macquarie and a couple local universities got "tasters". A lot of instructors went straight into teaching at RezBez.
+- Unique in that everyone was really motivated because they were teaching two weeks later.
+- Rough start with getting everyone to "gel" the first day. At the end of the first day everyone was pretty tightly connected. 
+- Not a lot of knowledge about SWC at Macquarie. Attendees (about 30%) didn't know much about how Carpentries works, not previous parts of the community. Had a few people who threw things off. 
+- Belinda used a "talking stick" to control vocals during the event.
+- Some push-back from some of the attendees during the start of the event. Broke through to them by the end. 
+- Comment from organizer that there weren't enough women in the training. Partners often push to put their staff in the first training cohort (because graduate students leave). The staff often skews towards male. 
+- "RezBez" is "research bazaar". Event at univerisities for people to find research collaborators and go to workshops to develop research skills. Cross disciplinary. Focuses on building participants research skillset.
+
+
+### Online, June 26-27 (https://carpentries-work.github.io/2017-06-26-ttt-online/)
+Trainers: Rayna, Jeff, Maneesha (Aleks observing)
+- How do you manage multiple sites at one online training?
+    - Mateusz: difficult. Sometimes people arrive at different times.  Need to have a consistent policy, if people don't show up on time, what do we do? 
+    - Greg: have them test AV in advance.
+    -  Mark: host should have obligation to test things ~30 minutes in advance
+    - Mateusz: Maybe not have Monday workshops so that things don't get messed up over the weekend
+
+- How do you manage different amounts of time a breakout activity takes?
+    - Mateusz - combine it with a coffee break - but then it cuts into their break time
+    - Greg - give people 5 minute warnings.  Can we record how long exercises actually take?
+    - Mark - designated contact at host sites to help manage time
+ 
+
+### June 19-23 In-person week-long DIBSI-TTT UC Davis 
+Trainers: Titus Brown and others. From us: Sue McClatchy, Karen Word, Erin Becker, Lex Nederbragt, with Tracy Teal, Chris Hamm, Amy Hodge https://dib-lab.github.io/2017-06-19-DIBSI-TTT/
+
+- Lex: 
+    - Full week meant they could spend more time on various modules.  Also did parts of checkout duting the week.
+    - Did lessons in different order.
+    - Included bias training from Anna Schneider, Unconscious Bias Project http://unconsciousbiasproject.org/
+    - Day long hackathon to work on genomics lessons - reviewing and merging PRs 
+    - Talked about workshos in other settings - corporate, undergrad
+    - Did teaching demos on site
+    - Trainees said they wanted more feedback from us.  Instructors who were not teaching added feedback to their exercises in the etherpad.  Very time consuming but worth it!  How can we include this in our regular trainings?
+        - Greg: We put the exercises in a google doc, and gave them feedback a few days later.  Not as effective as immediate feedback but still useful.  May be hard for the actual trainers but good for others to do. Examples:
+        - http://pad.software-carpentry.org/DIBSI-TTT-Monday from line 452 (formative assessment MCW exercise)
+        - http://pad.software-carpentry.org/DIBSI-TTT-Tuesday from line 54 (Faded examples)
+        - http://pad.software-carpentry.org/DIBSI-TTT-Wednesday from line 155 (learning objectives, feedback from Kristin Bass)
+        - People didn't do pre-reading so some people only prepared for 5 minutes
+
+- Chris: Talked about Carpentries model in industry, helped with teaching demos
+- Mark; Can we partner with a "Center for Teaching Excellence" or similar dept at universities we partner with?  
+- Lex: In Oslo pedagogical training is required to teach at university
+- Neal: Message from Neal Davis (U. Illinois): I reached out to teaching center (at Illinois) but they felt like they didn't have the bandwidth to concern themselves with it.
+
+- General thoughts:
+    - Jonah: Instructor training isn't as exhausting as regular workshops because there's so much group work time. 
+    - Erin: Has anyone else done events where one instructor is in person and one is virtual?
+
+### Teaching Git on the command line vs. via GitHub:
+    - Slides from Mozilla https://docs.google.com/presentation/d/1OcoMQgNyWHX9lUkLJ94nMoC6u-9FMbhPaERhJwvz7dc/edit#slide=id.g207b7bba3d_0_147
+    - John: Git is the only thing I have ever taught that has made a student cry.
+    - SourceTree - GUI that gives you all of the command line features for git. Available for Linux, Unix and Windows. https://www.sourcetreeapp.com/
+    - Amy: At Stanford, a lot of people are really excited about learning git. That's why they're signing up for workshops. But even Stanford students are overwhelmed by it. 
+    - Danielle: Depends a lot on the audience. 
+    
+## Upcoming training events
+
+### Open online, July 10-11, https://allegravia.github.io/2017-07-10-ttt-online-open/
+Trainers: Allegra, Mateusz
+
+
+- Switching to zoom platform
+    - Everyone will be connecting separately, not as sites
+    - Greg: When people pair up will they be in Zoom rooms or making their own connection using some other tool?
+    - Mateusz: We will be using Zoom rooms, testing it out this week.
+    - Greg: Advice - leave people in the same pairs for the whole training so they can keep connecting to the same people and don't spend time figuring it out over and over again
+    - Use google docs - can paste images 
+    - Collaborative tool:  https://hackmd.io/
+    - Mark: good for simple notetaking, no ability to chat (which is good to get quick questions answered).  Versioning system is not great.  Might not work with lots of distributed people.
+    - Greg: Advising against trying something new  
+
+
+
+### Online, July 13-14  https://jasonjwilliamsny.github.io/2017-07-13-jaxlab-instructor-training/
+Trainers: Anelda, Neil, Jason
+- Neil: our available times don't overlap. What can we do to ensure continuity?
+- Mateusz: don't digress on other topics.  Be strict on timing.
+- Lex: Another communication channel like slack.  Tiny overlaps during breaks, etc
+- Mark: Sharing anything about the group dynamics - does someone hog the stage, etc.
+
+
+### Open online, July 13-14  https://anenadic.github.io/2017-07-13-ttt-online/
+Trainers: Aleks, Martin, Stephen
+
+### Univ. of Arizona, July 25-26
+Trainers: Jeff and Erin
+Details TBD
+
+### QCIF, Brisbane, 27-28 July (partner training event) https://weaverbel.github.io/2017-07-27-qcif/
+Trainer: Belinda (and maybe Jonah remotely)


### PR DESCRIPTION
This is part of the process of transitioning the trainers group from being a subcommittee of the Software Carpentry Steering Committee. Old minutes have been copied from the [SWC board repo](https://github.com/swcarpentry/board/tree/master/subcommittees/) to here.