### PR TITLE
Add removal clause

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -91,3 +91,9 @@ to the change.
 1. After the two week comment period, a proposal moves to a vote among all trainers.
 A proposal is adopted with a quorum of 2/3 trainers in good standing voting (for,against, 
 or abstain) and a simple majority of the votes in favor. 
+
+## Removal
+
+If a Member consistently fails to meet the obligations outlined above, they may be removed by a unanimous vote of the other Members. A vote to remove a Member 
+must be announced in writing (in the meeting agenda) to all Members at least ten days in advance to vote on the removal. A vacated seat will be filled following 
+the procedure outlined in the Nominations and Elections section.


### PR DESCRIPTION
We don't have a clear consensus on this so I am adding a conservative option. I think it is important to have *something* available in the event that a Member ceases to be active in the group. Language approximately mirrors that of the EC, except for "unanimous" in place of "75%" because functionally 75% rounds to 4 on a panel of 5.

Relates to https://github.com/carpentries/trainers/issues/51