### PR TITLE
Add links to define each group

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -9,7 +9,7 @@ Reference: https://docs.carpentries.org/topic_folders/governance/committee-polic
 * Provide guidance and feedback as it relates to policies and procedures with respect to instructor training
 
 ## Powers and Responsibilities
-The authority and associated responsibilities proposed for this governing Committee, as distinct from the Trainers group as a whole and The Carpentries Core Team, are outlined in [this document](https://github.com/carpentries/trainers/blob/master/powers_responsibilities.md).
+The authority and associated responsibilities proposed for this governing Committee, as distinct from the [Trainers](https://docs.carpentries.org/topic_folders/instructor_training/duties_agreement.html) group as a whole and [The Carpentries Core Team](https://carpentries.org/team/), are outlined in [this document](https://github.com/carpentries/trainers/blob/master/powers_responsibilities.md).
 
 ## Membership
 
@@ -59,7 +59,7 @@ The authority and associated responsibilities proposed for this governing Commit
 
 #### Nominations and Elections
 
-All Instructor Trainers with Active status who are not part of the [Carpentries Core Team](https://carpentries.org/team/) will be eligible to vote in elections.
+All [Instructor Trainers](https://docs.carpentries.org/topic_folders/instructor_training/duties_agreement.html) with Active [status](https://docs.carpentries.org/topic_folders/instructor_training/duties_agreement.html#trainer-alumni-status) who are not part of the [Carpentries Core Team](https://carpentries.org/team/) will be eligible to vote in elections.
 
 New Members will be elected each year as vacancies occur. A general timeline for elections will occur annually as follows:
 * Mid November: The Committee identifies a point of contact for the election. This person should not be standing for re-election.

--- a/governance.md
+++ b/governance.md
@@ -1,8 +1,9 @@
 # Trainer Leadership Committee 
 
 Proposal date: November 18, 2020
-
-Reference: https://docs.carpentries.org/topic_folders/governance/committee-policy.html
+Updated: January 11, 2021
+ 
+This is the first of two public documents detailing the role of the proposed Trainers Leadership Committee, as required in [The Carpentries Bylaws](https://docs.carpentries.org/topic_folders/governance/committee-policy.html). See Powers and Responsibilities, below, for the second document.
 
 ## Purpose
 * Provide an inclusive, effective voice on behalf of and accountable to the trainer community.   

--- a/powers_responsibilities.md
+++ b/powers_responsibilities.md
@@ -1,5 +1,4 @@
-In proposing creation of a Leadership group with authority to act and responsibilities to fulfill, it is necessary to distinguish the powers and responsibilities
-specific to this group from those of existing community structures. This document proposes such distinctions as follows:
+This document details the powers and responsibilities of [Instructor Trainers](https://docs.carpentries.org/topic_folders/instructor_training/duties_agreement.html], elected [Leadership for the Trainer community](https://github.com/carpentries/trainers/blob/main/governance.md), and [The Carpentries Core Team](https://carpentries.org/team/). This is the second of two public documents detailing the role of the proposed Trainers Leadership Committee.
 
 ## Powers
 
@@ -38,7 +37,7 @@ specific to this group from those of existing community structures. This documen
 ## Responsibilities
 
 ### What responsibilities belong to the Trainer community?
-* Specified in Trainer Agreement
+* Specified in [Trainer Agreement](https://docs.carpentries.org/topic_folders/instructor_training/duties_agreement.html#trainer-agreement)
 
 ### What responsibilities belong to Leadership?
 * Recruit and approve nominees to serve in elected and appointed community roles


### PR DESCRIPTION
Responds to questions & requests regarding definitions of Trainers, Leadership, and Core Team. Also adds note clarifying that this is included in the public documentation of the proposed Committee

