### PR TITLE
Add draft of 2021-03-29 leadership meeting minutes

### DIFF
--- a/leadership_minutes/2021-03-29-leadership-minutes.md
+++ b/leadership_minutes/2021-03-29-leadership-minutes.md
@@ -1,0 +1,108 @@
+# Trainer Leadership Meeting 2021-03-29 23:00UTC
+
+_note: goal is to go easiest things first and leave more open ended things for later in the meeting_
+
+## Quick Proposal Reviews (Sarah, 5 min)
+
+1. Finalize decision on [martha's rules](https://github.com/carpentries/trainers/pull/74)
+    - Arin: should we consider changing quorum for such a small group? What happens if 2 can't be present? How useful is Martha's rules for a smaller group vs a larger group?
+    - Sarah: We definitely have a lot of things we could do. If we work with something roughly like this, we can offload a lot of the discussion out of meetings, and do more asychronously. We can have prepared proposals and have discussion only for things we really need to discuss. Maybe we should augment this to make it more clear about what we do by policy vs just vaguely discussing.
+    - Amanda: Had changed it originally to 4 members present because there's only 5 and if only one person is missing, we probably aren't going to get anywhere. Maybe what we actually want to do is something like everyone signing off on a PR, having an asynchronous voting mechanism
+    - Jeff: I like the proposal but have flashbacks to the movie "Death of Stalin" - parodies bureaucracy. At first this seemed like overkill. Having actually read the thing I think it is very nice and transparent and sets up a means to do things. Like the "likes" "can live with" "don't like" -- this seems like it will work well. Maybe we build in a 'review in 4 months.' If these rules result in time loss, we can re-visit.
+    - Sarah: would be good if we can generally accept that we can do things and then change them, not treat them as permanent
+    - Mark: concerned about everything needing a champion.
+    - Sarah: unclear what needs to be in the proposal, and what can just make it into the agenda. Not sure how to document that informal process.
+    - Arin: 4 month trial sounds good.
+    - Sarah: committing suggestions in PR.
+    - Missed some points about details regarding meetings being in this document, which has been renamed from MarthasRules.md to something more accurate, leader_meeting_rules.md
+    - **Approved**.
+2. [templates and discussions](https://github.com/carpentries/trainers/issues/75)
+    - if accept, PRs made after meeting then we can iterate on the text asynchronously, merge upon all? approval on PR or xx date
+    - for [IT/1229](https://github.com/carpentries/instructor-training/issues/1229): yes thank you @PeteEmbleton and @mariakna for this discussion. I learned something new here. However, our curriculum is already overflowing with content and trainees regularly report that the amount of supplemental material is overwhelming, so we're currently pretty narrowly focused on updates that refine and narrow the curriculum rather than adding new content. However, we *are* interested in supporting this type of discussion, so we're going to move this issue to a different location for future reference and continued discussion.
+3. [milestones](https://github.com/carpentries/trainers/issues/76)
+    - if accept, where do we document this?
+    - in meeting rules?
+    - Milesones mostly just gives things a different tag, but it can now have a due date. The tag has a unique shape rather than color. Goal is to be able to filter issues by the meeting date.
+    - **Approved**. (most can live with)
+4. [Public Documentation](https://docs.carpentries.org/topic_folders/governance/committee-policy.html#public-documentation) (from EC committee policy)
+    - where is this page/ what needs to be done?
+        - Where are other Carpentries <*> Committee pages?
+    - *Note from Karen: at this time, the EC has been asked to consider our existing documentation as meeting this requirement. Their expectations may change as they are considering guidelines for a governance body which may differ from Committee guidelines.*
+5. [Trainer agreement timeline](https://github.com/carpentries/trainers/issues/77)
+    - *not discussing content today, only timeline and number of steps in the process*
+    - Karen: it's great to have this done in time for the quarterly scheduling deadline. It won't be a disaster if it ends up running late.
+    - Mark: agrees this will work well
+    - Amanda: are the meetings our meetings or general Trainer meetings?
+    - Sarah: Both. Item 1. We would use our main meeting to decide what we want to do and how we want to do it. 2+ are mostly Trainer meetings.
+    - **Approved**.
+
+## Discussions
+
+1. Governance Update from EC (Karen, 5min)
+    - Have emailed Lex (chair [of EC]) for advice on continuing interaction
+2. Curriculum Update (Karen, 5)
+    - many changes to date are visible as a pull request in the [main repo](https://github.com/carpentries/instructor-training/pull/1215) or rendered on the [sandbox](https://data-lessons.github.io/instructor-training/)
+    - many of these constitute a first 'layer' with additional edits to come as content is adjusted around structural changes
+    - New work is first reviewed in the [sandbox](https://github.com/data-lessons/instructor-training/pulls), then merged after responding to comments there. Content merged into gh-pages on that repo becomes part of [PR 1215](https://github.com/carpentries/instructor-training/pull/1215) above.
+    - We need to think about policy on updates and whether we continue to use the sandbox
+    - We also need to think about onboarding, possibly concurrent with trainer training.
+        - How will we do this?
+        - We need to figure that out before we do it :)
+3. ~2a?~ Trainer Training Update (Karen, 5 min) :)
+    - Review process can wait, but application updates need to happen now.
+    - Propose adding one question:
+        - _What are three things that you consider to be most important to do or keep in mind when participating in a community of practice? Please explain._
+    - Sarah: didn't know what this was asking before introduction. Maybe with some expository text that explains that Trainers function as a community.
+    - Kelly: what are we trying to screen for?
+    - Amanda: Maybe we need a test audience for this. To see if people would give a good answer along the lines we are looking for.
+    - Arin: I think I particularly like the idea of framing it as a community of practice which is a distinct concept from other communities. That lays the groundwork for other questions. How do you see yourself as belonging to birds of the same feather, and others who have been doing this for a whie. We are getting new people into the mix. It is one thing to think about how they answer, but how are we going to interpret the responses? People may or may not be familiar with the notion of a community of practice. but how are we going to interpret the responses?
+    - Maybe can we get the 3 criteria that we need to assess, and start with the answer?
+    - Mark: do we allow for cultural differences in interpreting the answers to these questions?
+    - Karen: we can follow upon this asynchronously, maybe include the question but not weight it for this round.
+    - Mark & Jeff: +1
+4. ~3~ Private/Public discussions (Sarah, 5 min)
+    - how public should this decision process be?
+    - EC example:
+        - It seems like their notes are default-private, with public minutes posted here: https://github.com/carpentries/executive-council-info — while I think there are probably good reasons for them to operate this way, as some noted in our meeting that may not be the best model for this group.
+    - do we want a mechanism for private, accessible to all trainers?
+    - Amanda: if we set up the GitHub space with teams, if you put us all on the team, you. canuse the teams to give permissions but they also get their own special discussion board that is separate from the public discussion board. For each discussion you have public/private options.
+    - Karen: Team setup is in progress.
+    - Sarah: Last time we vaguely discussed that most things will be public. Do we want to discuss *what* will be public vs private?
+    - Jeff: We can start with a draft of things that are public vs private and then vote?
+    - Mark: Do we have levels? Public public, Public to Trainers, private within just this group?
+    - Sarah: We definitely have things that are private private, and public. Do we want a place where only Trainers can see things? e.g. Reasons we ask Trainees to repeat? This is sort of sensitive and maybe should be only Trainers
+    - Kelly: Seeing an issue on what should be private vs public may raise eyebrows
+    - Sarah: If I didn't see that, I would assume that they were doing an unknown number of things privately.
+    - Jeff: I think as long as we make it clear that certain info is clearly necessary to be private, and are thoughtful and as transparent with our opacity as we can possibly be the community will probably be supportive of that.
+    - Sarah: Are we in agreement to be public about what we are being private about?
+    - Arin: This can be a good candidate for putting Martha's rules in practice
+    - Amanda: Volunteering to create GitHub issue for this.
+5. ~4~ Projects, Procedurally: make decisions (Sarah, 10 min)
+    - multiple issues at different staged?
+    - brainstorm in meetings and then delegate?
+    - mixture?
+    - actions that are not policy/documentation? (next time)
+    - Scoping proposals within Martha's rules is an open question. For example, if we need to have a policy for maintianing the IT curriculum, do we propose to have the policy, or do we start with proposal for the policy?
+    - Mark: Don't think it makes sense to put in a full proposal if the group doesn't agree that we're going to deliberate on it. Should ask the group first if this is something we will address.
+    - Arin: +1
+6. ~5~ Projects, Content: delegate here (Sarah, 15min)
+    - [open from previous group](https://github.com/carpentries/trainers/issues/50)
+    - Trainer meeting coordination documentation
+    - Trainer Agreement
+    - IT curriculum maintainance policy
+        - Curriculum update Core team project timeline (Karen)
+        - do we want a policy about the onboarding process in place before or after this onboarding?
+    - Bonus Modules?
+    - Trainer Training?
+    - community building activities
+    - checkout and piloting
+7. ~6~ [Policy & IT Curriculum](https://github.com/carpentries/trainers/issues/78)
+    - Do we want to discuss this today or postpone?
+    - It doesn't have a one-sentence summary at the top! Will defer to next meeting.
+8. ~7~ Next meeting
+    - Which week within the month?
+        - Trainer meetings are 1st and 3rd.
+        - 2nd Monday would be after the first meeting of the month
+        - Next meeting 2021-04-12 23:00UTC https://www.timeanddate.com/worldclock/fixedtime.html?msg=Trainer+Leadership&iso=20210412T23
+
+(Karen: does anyone object to rescheduling this week's Trainer meeting? No.)

--- a/leadership_minutes/2021-03-29-leadership-minutes.md
+++ b/leadership_minutes/2021-03-29-leadership-minutes.md
@@ -85,6 +85,7 @@ _note: goal is to go easiest things first and leave more open ended things for l
     - Scoping proposals within Martha's rules is an open question. For example, if we need to have a policy for maintianing the IT curriculum, do we propose to have the policy, or do we start with proposal for the policy?
     - Mark: Don't think it makes sense to put in a full proposal if the group doesn't agree that we're going to deliberate on it. Should ask the group first if this is something we will address.
     - Arin: +1
+    - Sarah: ok, we will proceed with small proposals for project ideas that then we can move into full proposals after. 
 6. ~5~ Projects, Content: delegate here (Sarah, 15min)
     - Sarah: per above decision I will create proposals about doing each of these ideas and we'll delegate tasks at the next meeting
 7. ~6~ [Policy & IT Curriculum](https://github.com/carpentries/trainers/issues/78)

--- a/leadership_minutes/2021-03-29-leadership-minutes.md
+++ b/leadership_minutes/2021-03-29-leadership-minutes.md
@@ -86,16 +86,7 @@ _note: goal is to go easiest things first and leave more open ended things for l
     - Mark: Don't think it makes sense to put in a full proposal if the group doesn't agree that we're going to deliberate on it. Should ask the group first if this is something we will address.
     - Arin: +1
 6. ~5~ Projects, Content: delegate here (Sarah, 15min)
-    - [open from previous group](https://github.com/carpentries/trainers/issues/50)
-    - Trainer meeting coordination documentation
-    - Trainer Agreement
-    - IT curriculum maintainance policy
-        - Curriculum update Core team project timeline (Karen)
-        - do we want a policy about the onboarding process in place before or after this onboarding?
-    - Bonus Modules?
-    - Trainer Training?
-    - community building activities
-    - checkout and piloting
+    - Sarah: per above decision I will create proposals about doing each of these ideas and we'll delegate tasks at the next meeting
 7. ~6~ [Policy & IT Curriculum](https://github.com/carpentries/trainers/issues/78)
     - Do we want to discuss this today or postpone?
     - It doesn't have a one-sentence summary at the top! Will defer to next meeting.


### PR DESCRIPTION
Draft of the minutes for public consumption for the 2021-03-29 UTC leadership meeting.