### PR TITLE
Add draft holiday cancellation guide

### DIFF
--- a/policy/holiday-scheduling-process.md
+++ b/policy/holiday-scheduling-process.md
@@ -11,9 +11,13 @@ meeting collision is difficult to predict.
 ## Responsibilities
 
 + The decision to cancel a regularly scheduled trainers meeting will be at the 
-discretion of the Carpentries' Director of Instructor Training or a designated proxy. 
-+ Notification of such a cancellation should be made at least 72 hours before the
-scheduled meeting time through all normal meeting announcement communication channels. 
+discretion of the Carpentries' Director of Instructor Training or a designated 
+proxy. 
++ Notification of such a cancellation should be made at least 72 hours before 
+the scheduled meeting time through all normal meeting announcement communication 
+channels. 
 + Any member of the Carpentries Trainers community may notify the 
 Director of Instructor Training of significant holidays that conflict with 
 regularly scheduled trainer meetings. 
++ The Director of Instructor Training should attempt to accommodate meetings 
+when novice instructors (< 1year) have signed up for pre-workshop discussions

--- a/policy/holiday-scheduling-process.md
+++ b/policy/holiday-scheduling-process.md
@@ -12,7 +12,7 @@ meeting collision is difficult to predict.
 
 + The decision to cancel a regularly scheduled trainers meeting will be the 
 responsibility of the Carpentries' Director of Instructor Training. 
-+ Notification of such a cancellation should be made at least 24 hours before the
++ Notification of such a cancellation should be made at least 72 hours before the
 scheduled meeting time. 
 + The Carpentries Trainers community will be responsible for notifying the 
 Director of Instructor Training of significant holidays that conflict with 

--- a/policy/holiday-scheduling-process.md
+++ b/policy/holiday-scheduling-process.md
@@ -14,6 +14,6 @@ meeting collision is difficult to predict.
 discretion of the Carpentries' Director of Instructor Training or a designated proxy. 
 + Notification of such a cancellation should be made at least 72 hours before the
 scheduled meeting time through all normal meeting announcement communication channels. 
-+ The Carpentries Trainers community will be responsible for notifying the 
++ Any member of the Carpentries Trainers community may notify the 
 Director of Instructor Training of significant holidays that conflict with 
-regularly scheduled trainer meetings.
+regularly scheduled trainer meetings. 

--- a/policy/holiday-scheduling-process.md
+++ b/policy/holiday-scheduling-process.md
@@ -13,7 +13,7 @@ meeting collision is difficult to predict.
 + The decision to cancel a regularly scheduled trainers meeting will be at the 
 discretion of the Carpentries' Director of Instructor Training or a designated proxy. 
 + Notification of such a cancellation should be made at least 72 hours before the
-scheduled meeting time. 
+scheduled meeting time through all normal meeting announcement communication channels. 
 + The Carpentries Trainers community will be responsible for notifying the 
 Director of Instructor Training of significant holidays that conflict with 
 regularly scheduled trainer meetings.

--- a/policy/holiday-scheduling-process.md
+++ b/policy/holiday-scheduling-process.md
@@ -10,8 +10,8 @@ meeting collision is difficult to predict.
 
 ## Responsibilities
 
-+ The decision to cancel a regularly scheduled trainers meeting will be the 
-responsibility of the Carpentries' Director of Instructor Training. 
++ The decision to cancel a regularly scheduled trainers meeting will be at the 
+discretion of the Carpentries' Director of Instructor Training or a designated proxy. 
 + Notification of such a cancellation should be made at least 72 hours before the
 scheduled meeting time. 
 + The Carpentries Trainers community will be responsible for notifying the 

--- a/policy/holiday-scheduling-process.md
+++ b/policy/holiday-scheduling-process.md
@@ -20,4 +20,4 @@ channels.
 Director of Instructor Training of significant holidays that conflict with 
 regularly scheduled trainer meetings. 
 + The Director of Instructor Training should attempt to accommodate meetings 
-when novice instructors (< 1year) have signed up for pre-workshop discussions
+when novice trainers (< 1year) have signed up for pre-workshop discussions

--- a/policy/holiday-scheduling-process.md
+++ b/policy/holiday-scheduling-process.md
@@ -1,0 +1,19 @@
+# Scheduling: Trainers Meetings and Holidays
+
+## Rationale
+
+Regularly scheduled bi-monthly meetings of Carpentries Trainers may fall on a 
+major holiday, reducing participation by the trainers community. Given the 
+global distribution of Carpentries Trainers, and variation in observance of 
+major holidays, the degree to which any particular holiday will impact trainer 
+meeting collision is difficult to predict. 
+
+## Responsibilities
+
++ The decision to cancel a regularly scheduled trainers meeting will be the 
+responsibility of the Carpentries' Director of Instructor Training. 
++ Notification of such a cancellation should be made at least 24 hours before the
+scheduled meeting time. 
++ The Carpentries Trainers community will be responsible for notifying the 
+Director of Instructor Training of significant holidays that conflict with 
+regularly scheduled trainer meetings.


### PR DESCRIPTION
A draft of practice to use for cancelling trainers meeting for discussion at June Trainers leadership meeting (addresses #93 ).

Going to add everyone as a reviewer, although not sure that's the right mechanism for adopting this thing. :thinking: 