### PR TITLE
Add approved minutes procedure to leader meeting rules

### DIFF
--- a/policy/leader_meeting_rules.md
+++ b/policy/leader_meeting_rules.md
@@ -70,3 +70,20 @@ Accepted proposals will be linked to in the associated meeting minutes. Proposal
 ## Leadership Panel Meeting Minutes
 
 Meeting minutes will be added as a pull request by a submitter (secretary or delegate) and all members of the panel will review and approve the pull request.  The minutes will be merged for record after all voting members have approved the current version, any member who was not last to approve or Core Team members may merge minutes.
+
+## Specific Minutes Sharing Procedure
+
+- Proposals for upcoming meetings will be submitted as issues in the public trainers repository, and are always viewable by everyone
+- Meeting minutes will be taken in a private space that is limited to Trainer Leadership
+- During each meeting, as topics are discussed the group will decide if the upcoming topic should be redacted. If so, notes will not be recorded. Meeting minutes will be briefly discussed at the end of each meeting to determine if further redactions are needed
+- the Secretary will make a Pull request to the public trainers repository with the public meeting notes
+- Approval/edits of the minutes by Trainers Leadership will proceed from there 
+
+Important notes:
+- Unredacted minutes will never be posted to GitHub
+- Names of Trainer Leadership (who said what) will not be redacted
+- Names and identifying details of non-Leadership persons under discussion will sometimes be redacted. 
+- Content associated with names and identifying details of non-Leadership persons under discussion will sometimes be redacted.
+   - Redactions will only be made for identifying information that may adversely affect the person under discussion. This includes but is not necessarily limited to: Trainers Application decisions and recruitment decisions. Conversations that feature a great deal of identifying information may be redacted in full as in `<trainer applications were discussed>`
+- Trainer Leadership is not *required* to redact identifying information in cases where the benefit to disclosing that information to the Trainer Community would outweigh any negatives, such as offering congratulations. 
+- This procedure is subject to any applicable Carpentries privacy policies, and in cases where they conflict the Carpentries Privacy Polices always take precedence.


### PR DESCRIPTION
We didn't discuss this in the meeting, but I think for findability reasons, putting it with the meeting rules makes more sense than only keeping this content in the  proposal issue. 

I think this can be merged after a single approval, verifying that it's what we approved in #88 