### PR TITLE
Changed "bylaws" to "committee policy"

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -3,7 +3,7 @@
 Proposal date: November 18, 2020
 Updated: January 11, 2021
  
-This is the first of two public documents detailing the role of the proposed Trainers Leadership Committee, as required in [The Carpentries Bylaws](https://docs.carpentries.org/topic_folders/governance/committee-policy.html). See Powers and Responsibilities, below, for the second document.
+This is the first of two public documents detailing the role of the proposed Trainers Leadership Committee, as required in [The Carpentries Committee Policy](https://docs.carpentries.org/topic_folders/governance/committee-policy.html). See Powers and Responsibilities, below, for the second document.
 
 ## Purpose
 * Provide an inclusive, effective voice on behalf of and accountable to the trainer community.   


### PR DESCRIPTION
This document was written as required by the Committee Policy, not the Bylaws. The Committee Policy is a policy that is outside of The Carpentries bylaws. For reference, [here are the bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html)