### PR TITLE
Script  & action to initialize report with links

### DIFF
--- a/.github/workflows/initialize_report.yml
+++ b/.github/workflows/initialize_report.yml
@@ -13,6 +13,11 @@ jobs:
       with:
         python-version: 3.8
 
+    # install dependencies
+    - name: dependencies
+       run: |
+        pip install pandas
+
     # generate the report
     - name: Generate report
       run: python reports/get_links.py

--- a/.github/workflows/initialize_report.yml
+++ b/.github/workflows/initialize_report.yml
@@ -1,0 +1,26 @@
+on:
+  workflow_dispatch
+
+jobs:
+  check-contents:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # Install dependencies
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+
+    # generate the report
+    - name: Generate report
+      run: python reports/get_links.py
+
+    # start a pull request for it
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4
+      with:
+        commit-message: 'autodraft report content'
+        draft: true
+        title: EC Report

--- a/.github/workflows/initialize_report.yml
+++ b/.github/workflows/initialize_report.yml
@@ -15,8 +15,7 @@ jobs:
 
     # install dependencies
     - name: dependencies
-       run: |
-        pip install pandas
+       run: pip install pandas
 
     # generate the report
     - name: Generate report

--- a/.github/workflows/initialize_report.yml
+++ b/.github/workflows/initialize_report.yml
@@ -2,7 +2,7 @@ on:
   workflow_dispatch
 
 jobs:
-  check-contents:
+  generatereport:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -15,11 +15,13 @@ jobs:
 
     # install dependencies
     - name: dependencies
-       run: pip install pandas
+      run: pip install pandas
 
     # generate the report
     - name: Generate report
-      run: python reports/get_links.py
+      run: |
+        cd reports/
+        python get_links.py
 
     # start a pull request for it
     - name: Create Pull Request

--- a/reports/README.md
+++ b/reports/README.md
@@ -1,0 +1,39 @@
+# Trainer Leadership Reports to EC
+
+
+Per the Carpentries [Committee Policy]()
+the trainer leadership submits reports twice annually to the Carpentries
+Executive Committee.
+
+## Helper Notebook
+This folder also contains a markdown jupyter notebook that generates the links
+for that report. It is a markdown notebook for reasons of versioning, so it
+does not show the results in browser, but will run offline. It requires `pandas`
+and `jupytext`.
+
+
+## Helper Script + Action
+There is also a script file, that has an accompanying github action in
+`.github/workflows/initialize_report.yml`.  The action is set to be run
+manually. To run it:
+
+- Go to the Actions tab of the repository
+- Select this action in the Workflows panel on the left
+- On the right of the center panel choose "Run Workflow" on 'main' in the "Run Workflow" menu
+
+[GitHub Instructions to manually run an action](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow)
+
+All together the action file with the script will:
+- checkout the repo on GitHub
+- install python and pandas
+- run the script:
+    - use the github api to pull the list of the last 100 issues & PRs to the trainer repo
+    - put them into a DataFrame
+    - clean up the Dataframe
+    - select only the approved proposals (based on the label)
+    - generate a markdown link to the html page of approved proposal
+    - write those to a file
+- open a pull request with the initialized report file
+
+
+Then you can manually continue editing that pull request to complete the report.

--- a/reports/get_links.py
+++ b/reports/get_links.py
@@ -1,0 +1,74 @@
+import pandas as pd
+from datetime import date
+
+
+
+def get_links():
+    '''
+    generate md links for the trainer repo
+    '''
+
+    # URL to use GH API and query trainer repository for all issues, both open and closed up to the maximum (100)
+
+    trainer_issues_url = 'https://api.github.com/repos/carpentries/trainers/issues?per_page=100&state=all'
+
+    # read them into a dataframe
+    df_r = pd.read_json(trainer_issues_url)
+
+    unpack_cols = ['user','pull_request','reactions','labels']
+    # this dictionary makes it possible to ahve the following more compact.
+    #     it will for columns in the above list unpack them into a series and then prepend the name of the
+    #     source column to the new column names.  So the label column having {0:Proposed, 1: approved}
+    #     will turn into a label_0 column with a value of Proposed
+    #     by making it with Series and apply it then returns a DataFrame, by having a Series from each row
+    final_col = {True: lambda col,ser: ser.apply(pd.Series).rename(columns=lambda c: '_'.join([col,str(c)])),
+                False: lambda col,ser: ser}
+
+    #  This iterates over columns and makes a list of the Series of the column and
+    #      the dataframe produced by expanding the ones that were jsons
+    df_pieces = [final_col[col_i in unpack_cols](col_i,df_r[col_i]) for col_i in df_r.columns]
+
+    #  this takes the list of Series and DataFrame objects and combines them side by side to one dataFrame
+    df = pd.concat(df_pieces,axis=1)
+
+    # the label columns are still objects, unpack those more
+
+    label_cols = ['labels_0','labels_1']
+    #
+    label_cols = [df[l].apply(pd.Series).rename(columns=lambda c: '_'.join([l,str(c)])) for l in label_cols]
+
+    df = pd.concat([df]+label_cols,axis=1)
+
+    # create filters
+    approved = df['labels_1_name']=='approved'
+    proposal = df['labels_0_name']=='Proposal'
+
+    # create filtered dataframes
+    df_approved = df[approved]
+    df_proposal = df[proposal]
+
+    mdlink = lambda r: '['+ r['title'] + ']('+ r['html_url'] + ')'
+    df_approved['md'] = df_approved.apply(mdlink,axis=1)
+
+
+    # create file name
+    date_stamp = date.today().isoformat()
+    # will output like YYYY-MM-DD
+    file_name = date_stamp[:8] + 'report-to-ec.md'
+
+    # begin file with prelude
+    prelude_sections = ['# '+date_stamp, '## summary', '## approved', '']
+    # empty to make space
+    prelude = '\n\n'.join(prelude_sections)
+    with open(file_name,'a') as f:
+        f.write(prelude)
+
+    # draft report with md link list by writing each line to the file opened
+    #    in append mode
+    approved_links = '\n - '.join(df_approved['md'].to_list())
+    with open(file_name,'a') as f:
+        f.write(approved_links)
+
+
+if __name__ == '__main__':
+    get_links()

--- a/reports/get_links.py
+++ b/reports/get_links.py
@@ -47,6 +47,8 @@ def get_links():
     df_approved = df[approved]
     df_proposal = df[proposal]
 
+    # add a column with markdown formatted links by applying a small
+    #  function (a lambda function) to each row (axis=1) 
     mdlink = lambda r: '['+ r['title'] + ']('+ r['html_url'] + ')'
     df_approved['md'] = df_approved.apply(mdlink,axis=1)
 

--- a/reports/get_links.py
+++ b/reports/get_links.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from datetime import date
 
-
+# Contact for issues: @brownsarahm, smb@sarahmbrown.org
 
 def get_links():
     '''


### PR DESCRIPTION
This provides a script and github action that generates a pull request with a single file with the links as an initialization for the trainer EC reports. This makes it so that a chair of the leadership panel can use the script without having to install python locally or clone the report.  The only external dependency is pandas. 

[example initialization report](https://github.com/brownsarahm/trainers/pull/4/files#diff-f8d3b209f69837f1de25e6b713b3831afe2ce258be74506bf8d2944ae60f0a5e) 

I'm tagging members of the infrastructure team to especially review the code file and action files so that this more likely maintainable by others besides me. 

I tagged Mark as the next person responsible for using this script, primarily to review the README instructions. 

I tagged Karen as the Core team member most likely to support the next transition of the leadership panel chair role also to primarily review the README instructions. 

Other members of trainer leadership or other trainers are welcome to provide reviews and feedback. 