### PR TITLE
Form for meeting topic proposals. 

### DIFF
--- a/.github/ISSUE_TEMPLATE/trainer_meeting_topic.yml
+++ b/.github/ISSUE_TEMPLATE/trainer_meeting_topic.yml
@@ -22,6 +22,7 @@ body:
       options:
         - label: Meeting 1 (UTC 14:00)
         - label: Meeting 2 (UTC 22:00)
+        - label: None
         - label: other (explain below)
   - type: textarea
     id: scheduling

--- a/.github/ISSUE_TEMPLATE/trainer_meeting_topic.yml
+++ b/.github/ISSUE_TEMPLATE/trainer_meeting_topic.yml
@@ -1,7 +1,8 @@
 name: Template for Trainer Meeting Topics
 description: Suggest a topic for a trainer meeting
-title: "[Trainer Meeting]:  a short topic "
+title: "[Trainer Meeting]:  a short title "
 labels: ["trainermeeting"]
+assignees: karenword
 body:
   - type: markdown
     attributes:
@@ -11,7 +12,7 @@ body:
     id: title
     attributes:
       label: A short title
-      description: a short title for your meeting topic
+      description: a short title for your meeting topic, this may be the same as the issue title
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/trainer_meeting_topic.yml
+++ b/.github/ISSUE_TEMPLATE/trainer_meeting_topic.yml
@@ -7,11 +7,18 @@ body:
     attributes:
       value: |
        Thanks for contributing a topic!
+  - type: input
+    id: title
+    attributes:
+      label: A short title
+      description: a short title for your meeting topic
+    validations:
+      required: true
   - type: textarea
     id: intro
     attributes:
       label: Introduce the topic
-      description: describe how the topic would be introduced for the trainer meeting including and background
+      description: describe how the topic would be introduced for the trainer meeting including any background
     validations:
       required: true
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/trainer_meeting_topic.yml
+++ b/.github/ISSUE_TEMPLATE/trainer_meeting_topic.yml
@@ -1,0 +1,31 @@
+name: Template for Trainer Meeting Topics
+description: Suggest a topic for a trainer meeting
+title: "[Trainer Meeting]:  a short topic "
+labels: ["trainermeeting"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+       Thanks for contributing a topic!
+  - type: textarea
+    id: intro
+    attributes:
+      label:Introduce the topic
+      description: describe how the topic would be introduced for the trainer meeting including and background
+    validations:
+      required: true
+  - type: checkboxes
+    id: time
+    attributes:
+      label: Which trainer meeting time would you host?
+      description: you may select both or none to say that you do not want to host the topic
+      options:
+        - Meeting 1 (UTC 14:00)
+        - Meeting 2 (UTC 22:00
+  - type: textarea
+    id: scheduling
+    attributes:
+      label: Are there any scheduling concerns? 
+      description: this may include timeliness of the topic or limits on your ability to host the meeting
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/trainer_meeting_topic.yml
+++ b/.github/ISSUE_TEMPLATE/trainer_meeting_topic.yml
@@ -10,7 +10,7 @@ body:
   - type: textarea
     id: intro
     attributes:
-      label:Introduce the topic
+      label: Introduce the topic
       description: describe how the topic would be introduced for the trainer meeting including and background
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/trainer_meeting_topic.yml
+++ b/.github/ISSUE_TEMPLATE/trainer_meeting_topic.yml
@@ -20,8 +20,9 @@ body:
       label: Which trainer meeting time would you host?
       description: you may select both or none to say that you do not want to host the topic
       options:
-        - Meeting 1 (UTC 14:00)
-        - Meeting 2 (UTC 22:00
+        - label: Meeting 1 (UTC 14:00)
+        - label: Meeting 2 (UTC 22:00)
+        - label: other (explain below)
   - type: textarea
     id: scheduling
     attributes:


### PR DESCRIPTION
This PR implements #180 

[ see the preview in my fork](https://github.com/brownsarahm/trainers/blob/previewform/.github/ISSUE_TEMPLATE/trainer_meeting_topic.yml)

We may want to add/revise questions for proposing a time? 