### PR TITLE
Change schedule for elections

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Nov 16 (As Needed)
 Dec 7 (Primary) - pre/post discussion. 
 Dec 21 (As Needed)  
 2024. 
-Jan 18 - Reserved for Leadership Elections  
-Feb 1 (Primary)  
+Jan 18 (Primary) - pre/post discussion 
+Feb 1 - Reserved for Leadership elections  
 Feb 15 (As Needed)  
 Mar 7 (Primary)  
 Mar 21 (As Needed)  

--- a/governance.md
+++ b/governance.md
@@ -17,7 +17,7 @@ The authority and associated responsibilities proposed for this governing Commit
 * Five (5) voting members, listed on the [README of the trainers repo](README.md)
 	* Instructor Trainer with Active badge status
 	* Carpentries Core Team members are not eligible
-	* expected term of service is one year, with option to serve up to two years before standing for re-election (except where term limits apply)
+	* term is for one year
 	* term limit of three (3) consecutive years
 * Chairperson
 	* elected by the Committee members at the first meeting after elections

--- a/governance.md
+++ b/governance.md
@@ -1,7 +1,7 @@
 # Trainers Leadership Committee 
 
-Proposal date: November 18, 2020
-Updated: January 11, 2021
+Created: November 18, 2020
+Updated: December 1, 2023
  
 This is the first of two public documents detailing the role of the proposed Trainers Leadership Committee, as required in [The Carpentries Committee Policy](https://docs.carpentries.org/topic_folders/governance/committee-policy.html). See Powers and Responsibilities, below, for the second document.
 
@@ -17,7 +17,7 @@ The authority and associated responsibilities proposed for this governing Commit
 * Five (5) voting members, listed on the [README of the trainers repo](README.md)
 	* Instructor Trainer with Active badge status
 	* Carpentries Core Team members are not eligible
-	* term is for one year
+	* expected term of service is one year, with option to serve up to two years before standing for re-election (except where term limits apply)
 	* term limit of three (3) consecutive years
 * Chairperson
 	* elected by the Committee members at the first meeting after elections
@@ -65,8 +65,8 @@ All [Instructor Trainers](https://docs.carpentries.org/topic_folders/instructor_
 New Members will be elected each year as vacancies occur. A general timeline for elections will occur annually as follows:
 * Mid November: The Core Team Liaison identifies a point of contact for the election. This person may be the Core Team Liaison or any Trainer not standing for election.
 * Early December: Elections announced, Self-nominations open
-* Mid January: Self-nominations close, entries posted, dedicated Trainer meeting held to introduce candidates
-* Late January: Trainers vote 
+* Late January: Self-nominations close, entries posted, dedicated Trainer meeting held to introduce candidates
+* Early February: Trainers vote 
 * March 1: Responsibility transferred to new Members
 
 If the seat of a Member becomes vacant after March 1 but before December 1, the Committee will attempt to fill the seat with a non-elected nominee from the most recent election, in the order of votes received. If this fails, the Committee may appoint any Active Trainer to fill the seat until the next election.


### PR DESCRIPTION
EDITED:
This PR proposes changes to election schedule only. Previously proposed changes to Leadership terms have been reverted. 
- The first Trainer meeting of the year is typically held in late January, and the holiday pause can mean an extended break between pre/post discussion meetings. This proposal moves elections to February, reserving the January meeting for pre/post discussions.
