### PR TITLE
Meeting dates through 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,27 +43,30 @@ Primary meetings are always held; "As Needed" meetings are held only if there is
 If you would like to propose cancellation of a scheduled meeting due to holidays or other widespread conflicts, please submit an [Issue](https://github.com/carpentries/trainers/issues) 
 with this request for consideration by the Trainers Leadership Committee or send an [email](mailto: instructor.training@carpentries.org) to The Carpentries Core Team.
 
-Apr 6 (Primary) - pre/post discussion  
-Apr 20 (As Needed)  
-May 4 (Primary) - pre/post discussion  
-May 18 (As Needed)  
-Jun 1 (Primary) - pre/post discussion  
-Jun 15 (As Needed)  
-Jul 6 (Primary) - pre/post discussion  
-Jul 20 (As Needed)  
-Aug 3 (Primary) - pre/post discussion  
-Aug 17 (As Needed)  
-Sep 7 (Primary) - pre/post discussion  
-Sep 21 (As Needed)  
-Oct 5 (Primary) - pre/post discussion  
-Oct 19 (As Needed)  
-Nov 2 (Primary) - pre/post discussion. 
-Nov 16 (As Needed)  
-Dec 7 (Primary) - pre/post discussion. 
 Dec 21 (As Needed)  
 2024. 
 Jan 18 (Primary) - pre/post discussion 
 Feb 1 - Reserved for Leadership elections  
 Feb 15 (As Needed)  
-Mar 7 (Primary)  
+Mar 7 (Primary) - pre/post discussion
 Mar 21 (As Needed)  
+Apr 4 (Primary) - pre/post discussion 
+Apr 18 (As Needed)
+May 2 (Primary) - pre/post discussion
+May 16 (As Needed)
+June 6 (Primary) - pre/post discussion
+June 20 (As Needed)
+July 4 - TBD *Core Team availability limited due to US Holiday*
+July 18 (As Needed)
+Aug 1 (Primary) - pre/post discussion
+Aug 15 (As Needed)
+Sept 5 (Primary) - pre/post discussion
+Sept 19 (As Needed)
+Oct 3 (Primary) - pre/post discussion
+Oct 17 (As Needed)
+Nov 7 (Primary) - pre/post discussion
+Nov 21 (As Needed)
+Dec 5 (Primary) - pre/post discussion
+Dec 19 (As Needed)
+
+


### PR DESCRIPTION
Adds dates through December 2024. 

Notes:
- Easter Sunday is March 31. We have not been canceling meetings during the week following Easter, but we recognize that there is often low attendance due to extended holidays in some areas.
- July 4 is a US Holiday. While we often do not cancel events due to local/regional holidays, impacts on Core Team availability may make it more practical to cancel on this date. It is listed as "TBD".
