### PR TITLE
Update committee members in meeting rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ The trainer community self governs as per the [governance](governance.md) docume
 The elected Trainers Leadership Committee operates according to their [meeting rules](policy/leader_meeting_rules.md).
 
 Elected members of the Trainers Leadership Committee as of March, 2023 are:
-- Mark Crowe (chair)
-- Paola Corrales
-- Trisha Adamus
+- Liz Stokes (chair)
 - Annajiat Alim Rasel
-- Nathaniel Porter (secretary)
+- Nathaniel Porter
+- Md Intekhabul Hafiz
+- Jon Wheeler (secretary)
 
 
 ## 2023-4 Meeting Schedule

--- a/policy/leader_meeting_rules.md
+++ b/policy/leader_meeting_rules.md
@@ -56,11 +56,11 @@ to date.
 ## Suffrage
 
 1.  The following people are currently voting members of this project:
-    -   Mark Crowe
-    -   Paola Corrales
-    -   Trisha Adamus
+    -   Liz Stokes
     -   Annajiat Alim Rasel
     -   Nathaniel Porter
+    -   Md Intekhabul Hafiz
+    -   Jon Wheeler
 
 2.  To become a voting member:
     1.  [Members must be elected](https://github.com/carpentries/trainers/blob/main/governance.md#nominations-and-elections)


### PR DESCRIPTION
EDITED: I have removed my previous pull request, since this request includes both changes.

The leadership meeting rules under "policy" have been updated to include the current leadership, and the roster of leadership committee members in the README has also been updated.