### PR TITLE
add TLC minutes from June 13, 2024

### DIFF
--- a/leadership_minutes/2024/2024-06-13-leadership-minutes.md
+++ b/leadership_minutes/2024/2024-06-13-leadership-minutes.md
@@ -1,0 +1,67 @@
+Trainers Leadership June 2024-06-13
+
+Attendance
+
+Present: Jonathan Wheeler, Liz, Nathaniel, Annajiat
+Apologies: Intekhab, Sher
+Notetaker: Annajiat, Jon
+Agenda and notes:
+
+1.  Actions from last meeting
+    -   Jon will submit a proposal as a GitHub issue to update minutes approval to 2 weeks (completed)
+    -   Someone from TLC to boost Q3 signup (with link) in Trainers Slack. (completed)
+    -   Jon will submit a proposal as a GitHub issue to determine a process for closing issues that do not include pull requests. (completed)
+2.  Core team update
+    -   Only about 50% of trainers completed the initial survey.
+    -   Recent call for additional trainings was filled up.
+3.  Current activities (approved proposals)
+    -   Trainers meeting guide
+        [https://github.com/carpentries/trainers/issues/201](https://github.com/carpentries/trainers/issues/201)
+        -   Sher & Danielle running different meetings to best of their efforts. Having this guide developed is worth pursuing to strengthen trainer community
+        -   Share with trainer meetings to get feedback next week
+            1.  Include "updates from trainers-leadership" in trainers meeting agenda
+        -   Jon taking the lead of development, follow up in slack, update in next meeting
+        -   Location for final version:[https://github.com/carpentries/docs.carpentries.org/blob/main/topic_folders/instructor_training/trainers_guide.md](https://github.com/carpentries/docs.carpentries.org/blob/main/topic_folders/instructor_training/trainers_guide.md)
+    -   Automating trainer status renewal
+        [https://github.com/carpentries/trainers/issues/261](https://github.com/carpentries/trainers/issues/261)
+        -   Nathaniel: We have a rubric in terms of what will satisfy for automatic renewal. Last year things were not strictly enforced, in order to understand what people are doing and how to account for different types of activities.
+        -   Discussion of alignment of membership discount criterion advertised two days back (June 11) and trainer status renewal requirements
+        -   Annajiat: There maybe a relationship between active trainer status and membership. Some of the rationale for the discount maybe to drive membership up. Also, some renewal requirements may have been relaxed during COVID.
+        -   Nathaniel can collate the recommendations from last year's Leadership on what would constitute active renewal, but may need an @ tag or reminder
+4.  Proposals and pull requests: will be voted on before next leadership
+    -   Process to close outstanding issues
+        [https://github.com/carpentries/trainers/issues/295](https://github.com/carpentries/trainers/issues/295)
+    -   Shorten wait time for minutes approval
+        [https://github.com/carpentries/trainers/issues/294](https://github.com/carpentries/trainers/issues/294)
+    -   Consolidate two pages on becoming an instructor
+        [https://github.com/carpentries/trainers/issues/292](https://github.com/carpentries/trainers/issues/292)
+    -   Pilot enhanced instructor training
+        [https://github.com/carpentries/trainers/issues/286](https://github.com/carpentries/trainers/issues/286)
+        -   Development as a university training
+        -   Pilot in Spring/Fall 2025
+        -   Would require leadership approval to treat as official instructor certification due to differences in format (also probably to provide imprimatur)
+    -   Annajiat: (Nathaniel will forward these to the IT Maintainers Slack as ready to
+        resolve/close)
+        -   Issues:
+            1.  To discuss
+                a.  [https://github.com/carpentries/trainer-training/issues/56](https://github.com/carpentries/trainer-training/issues/56)
+                b.  [https://github.com/carpentries/instructor-training/issues/1294](https://github.com/carpentries/instructor-training/issues/1294)
+                c.  [https://github.com/carpentries/instructor-training/issues/1159](https://github.com/carpentries/instructor-training/issues/1159)
+                d.  [https://github.com/carpentries/instructor-training/issues/1072](https://github.com/carpentries/instructor-training/issues/1072)
+                e.  [https://github.com/carpentries/instructor-training/issues/803](https://github.com/carpentries/instructor-training/issues/803)
+                f.  [https://github.com/carpentries/instructor-training/issues/721](https://github.com/carpentries/instructor-training/issues/721)
+            2.  Closed
+                a.  [https://github.com/carpentries/instructor-training/issues/727](https://github.com/carpentries/instructor-training/issues/727)
+5.  Additional items
+    -   Asynchronous decision making - past practice and current needs
+    -   Redaction check (standing item)
+    -   Confirm the next back up meeting
+6.  Action items
+    -   Liz will send an appointment confirmation for next meeting.
+    -   Nathaniel will look up info from last year's trainer active status renewal process. By the next meeting.
+    -   Initiate development of a Trainer's Meeting Guide (Jon), by trainers' meeting June 20/21
+        -   Via document in appropriate directory of repository (most likely policy)
+        -   Include current info from etherpad
+    -   Everyone: review current proposals and comment per Martha's
+        rules by 1 day before July 10/11.
+7.  Next meeting: July 11 0:00 UTC


### PR DESCRIPTION
Adding draft minutes of the Trainers Leadership Committee meeting from 2024-06-13 0:00 UTC.

Please review and edit as needed prior to approval. Approval can be given here or in Slack.
