### PR TITLE
add 2024-09-27 leadership draft minutes

### DIFF
--- a/leadership_minutes/2024/2024-09-27-leadership-minutes.md
+++ b/leadership_minutes/2024/2024-09-27-leadership-minutes.md
@@ -1,0 +1,29 @@
+Trainers Leadership September 2024-09-27
+
+Attendance:
+Present: Jon, Liz
+Apologies: Sher
+Notetaker: Jon
+
+## Agenda and notes
+
+1.  Core team update
+	1. Updating the Carpentries Website/Handbook and we are developing 
+		1. [Instructor Training FAQ](https://carp-new-website.netlify.app/instructor-training/instructor-training-faq/)
+			1. Please feel free to add additional questions. WIT will begin to populate the answers and group the questions
+		 2.  [Trainers Leadership Handbook](https://docs.google.com/document/d/1XAZKSM9xVXU1PB8EokfmZWKB8r8-_0KqilM7VIb2A48/edit)
+			 1. Would like for the committee to fill in as much information as possible. 
+	2. Several months of Trainers Meeting Notes need approval in the [repo](https://github.com/carpentries/trainers/tree/main/minutes) 
+		1. Who should I assign to review? 
+			1. Trainers Leadership Committee
+		2. Jon and Liz reviewed pull requests and approved/merged any that were a month or more old.
+			1. June trainer meeting minutes have a pending question to resolve.
+		3. October Trainers Meeting
+			1. Introduce the new trainees! 
+2.  Additional business
+	1. Redaction check
+	2. Action items (with responsible person and timeline)
+		1. Jon will reach out via Slack and email to encourage TLC to vote on outstanding proposals. 
+		2. Jon can poll the TLC about setting a new meeting time. Will reach out via Slack and email.
+3.  Next meeting: October 11 00:00 UTC
+	1. Jon has a likely conflict.


### PR DESCRIPTION
We lacked a quorum at our September TLC meeting, but Liz and I did some PR maintenance and discussed the need to possibly change the meeting time. Adding minutes for the sake of transparency.