### PR TITLE
add draft trainers meeting guide

### DIFF
--- a/policy/trainers_meeting_guide.md
+++ b/policy/trainers_meeting_guide.md
@@ -33,7 +33,7 @@ Generated with assistance from ChatGPT, version 4o.
         - Pre/post-training discussions (for the first monthly meeting).
         - Community announcements.
         - A "topic of the month."
-    3. Publish the finalized agenda on the etherpad and community channels.
+    3. Publish the finalized agenda on the etherpad and share highlights on community channels.
       
 ## 4. **Identify Meeting Lead(s)**
 

--- a/policy/trainers_meeting_guide.md
+++ b/policy/trainers_meeting_guide.md
@@ -11,7 +11,7 @@ Generated with assistance from ChatGPT, version 4o.
 - **Process**:
     1. Coordinate with the Core Team to avoid conflicts with other events.
     2. Set two meeting times to accommodate global time zones. Times are currently UTC 14:00 and UTC 23:00, on the first and third Thursday of the month. 
-	    1. Changes to these times and dates should be based on unanimous consensus of the active Instructor Trainer community.
+	    1. Changes to these times and dates should be based on consensus of the active Instructor Trainer community.
     3. Announce schedules and ensure they are added to the community calendars. Remind Instructor Trainers every October 1 about re-importing calendar items to accommodate daylight savings changes.
 
 ## 2. **Call for Topics**
@@ -28,11 +28,11 @@ Generated with assistance from ChatGPT, version 4o.
 
 - **Responsibility**: ITLC with input from the Instructor Trainer community.
 - **Process**:
-    1. Review proposed topics from the etherpad and prioritize them based on community interest and relevance.
+    1. Review proposed topics and prioritize them based on community interest and relevance.
     2. Confirm the agenda for each meeting, typically focusing on:
         - Pre/post-training discussions (for the first monthly meeting).
         - Community announcements.
-        - A "topic of the month."
+        - A topic for discussion.
     3. Publish the finalized agenda on the etherpad and share highlights on community channels.
       
 ## 4. **Identify Meeting Lead(s)**
@@ -63,6 +63,7 @@ Generated with assistance from ChatGPT, version 4o.
 
 - Ensure at least one annual discussion to share updates on the Instructor Trainer program, as per committee guidelines.
 - Facilitate special meetings for significant changes or decisions requiring Instrucor Trainer input.
+- Introduce candidates for trainer leadership with time for Q&A.
 
 ## 7. **Additional Tips**
 

--- a/policy/trainers_meeting_guide.md
+++ b/policy/trainers_meeting_guide.md
@@ -1,16 +1,105 @@
-## Outline
+Generated with assistance from ChatGPT, version 4o. 
+- Outline by JW.
+- Draft elaborations by ChatGPT based on Core Team meeting documentation.
+- Elaborations edited by JW.
+# Trainers Meeting Guide
 
-1. Set the schedule
-	1. [Trainers Leadership Committee](https://github.com/carpentries/trainers/blob/main/powers_responsibilities.md#what-powers-belong-to-the-trainers-leadership-committee)
-2. Call for topics
-	1. Community channels
-	2. Space to [propose a topic](https://pad.carpentries.org/trainers#L27) in the trainers etherpad
-		1. Process was in use 2022-2023, but may not be current
-3. Set the agenda
-	1. [Trainer community](https://github.com/carpentries/trainers/blob/main/powers_responsibilities.md#what-powers-belong-to-the-trainer-community)
-4. Identify meeting lead(s)
-	1. Trainer meeting leads is a community role that is filled by the [Trainers Leadership Committee](https://github.com/carpentries/trainers/blob/main/powers_responsibilities.md#what-responsibilities-belong-to-the-trainers-leadership-committee).
-	2. A brief [process for hosting meetings](https://pad.carpentries.org/trainers#L26) is described in the etherpad. 
-		1. Process is voluntary - a trainer reviews upcoming topics and signs up via GitHub to host a topic.
-			1. This references the same GitHub topic board as 2.2, above. Process may not be in current use.
-5. Hosting meetings
+## 1. **Set the Schedule**
+
+- **Responsibility**: The Trainers Leadership Committee (TLC).
+- **Timing**: Schedule meetings well in advance, ideally annually.
+- **Process**:
+    1. Coordinate with the Core Team to avoid conflicts with other events.
+    2. Set two meeting times to accommodate global time zones. Times are currently UTC 14:00 and UTC 23:00, on the first and third Thursday of the month. 
+	    1. Changes to these times and dates should be based on unanimous consensus of the active trainer community.
+    3. Announce schedules and ensure they are added to community calendars. Remind trainers every October 1 about re-importing calendar items to accommodate daylight savings changes.
+
+## 2. **Call for Topics**
+
+- **Responsibility**: Trainer community members, facilitated by TLC.
+- **Process**:
+    1. Announce a call for topics via community channels (e.g., Slack, mailing lists).
+    2. Encourage members to propose topics in the [trainers etherpad](https://pad.carpentries.org/trainers) under the "Propose a Topic" section.
+    3. Collect additional ideas from recent discussions, Slack threads, and survey feedback.
+- **Tips**:
+    - Highlight any specific themes or areas of focus for upcoming meetings.
+
+## 3. **Set the Agenda**
+
+- **Responsibility**: TLC with input from the Trainer community.
+- **Process**:
+    1. Review proposed topics from the etherpad and prioritize them based on community interest and relevance.
+    2. Confirm the agenda for each meeting, typically focusing on:
+        - Pre/post-training discussions (for the first monthly meeting).
+        - Community announcements.
+        - A "topic of the month."
+    3. Publish the finalized agenda on the etherpad and community channels.
+
+## 4. **Identify Meeting Lead(s)**
+
+- **Responsibility**: TLC or volunteer trainers.
+- **Process**:
+    1. Use the etherpad or GitHub to sign up volunteers to host meetings.
+    2. If no one volunteers, the TLC can reach out to the trainer community.
+    3. TLC members will lead meetings for which no alternative host has volunteered.
+- **Role of the Meeting Lead**:
+    - Review the agenda and prepare to facilitate discussions.
+    - Ensure the etherpad is set up with the meeting template.
+
+## 5. **Hosting the Meeting**
+
+- **Preparation**:
+    - Confirm the Zoom link and update the etherpad with the meeting template.
+    - Send a reminder email 2-3 days before the meeting (see email template).
+- **During the Meeting**:
+    1. Start on time and do introductions with an icebreaker.
+    2. Do any pre/post-training discussions, followed by announcements and the topic of the month.
+    4. Note attendance on the etherpad and ensure key discussion points are recorded.
+- **After the Meeting**:
+    1. Submit meeting notes and attendance to the [Trainers repo](https://github.com/carpentries/trainers/tree/main/minutes).
+    2. Add attendance to the Core Team's spreadsheet.
+
+## 6. **Annual or Special Topics**
+
+- Ensure at least one annual discussion to share updates on the Trainer program, as per committee guidelines.
+- Facilitate special meetings for significant changes or decisions requiring trainer input.
+
+## 7. **Additional Tips**
+
+- **Community Input**: Regularly solicit feedback from trainers about meeting structure and topics.
+- **Inclusivity**: Ensure that meeting times and discussions are accessible and inclusive for all trainers globally.
+- **Documentation**: Keep a consistent record of all meetings to maintain transparency and support new trainers.
+
+## 8. **Email Templates**
+
+### Meeting reminder Template:
+
+**Before sending email, prepare Etherpad using template text at the bottom of the page. This will generate the time-date links to replace those in the email template below.**
+
+Hi Trainers,
+
+At this week's meeting, we will talk about [       topic of the month      ]! As this is our second meeting this month, we will not set aside time for pre/post training discussions. Please save those for our next meeting on [date]!
+
+[Some text about why it's interesting]
+
+[Maybe discussion questions to come prepared to answer]
+
+**Meeting 1:** [DATE]  UTC 14:00; Visit[ [](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20210903T14)[this link](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20210903T14) ] for your local time
+
+**Meeting 2:** [DATE]  UTC 23:00; Visit [ [](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20210903T23)[this link](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20210903T23) ] for your local time
+
+Etherpad: [](https://pad.carpentries.org/trainers)[https://pad.carpentries.org/trainers](https://pad.carpentries.org/trainers)
+
+Zoom: [](https://carpentries.zoom.us/my/carpentriesroom2?pwd=WmVCOUlPUm1laFk5SUp1UWg5cjhEUT09)[https://carpentries.zoom.us/my/carpentriesroom2?pwd=WmVCOUlPUm1laFk5SUp1UWg5cjhEUT09](https://carpentries.zoom.us/my/carpentriesroom2?pwd=WmVCOUlPUm1laFk5SUp1UWg5cjhEUT09)
+
+Hope you can join us!
+
+### Meeting cancellation Template:
+
+Hi Trainers,
+
+We will not be using our meeting time scheduled for this week. Our next meeting will be on [DATE].
+
+If you have time set aside, consider taking a moment to [ suggestion for contributing time, e.g. submitting instructor notes or completing quarterly scheduling form]
+
+Have a great week!

--- a/policy/trainers_meeting_guide.md
+++ b/policy/trainers_meeting_guide.md
@@ -1,0 +1,16 @@
+## Outline
+
+1. Set the schedule
+	1. [Trainers Leadership Committee](https://github.com/carpentries/trainers/blob/main/powers_responsibilities.md#what-powers-belong-to-the-trainers-leadership-committee)
+2. Call for topics
+	1. Community channels
+	2. Space to [propose a topic](https://pad.carpentries.org/trainers#L27) in the trainers etherpad
+		1. Process was in use 2022-2023, but may not be current
+3. Set the agenda
+	1. [Trainer community](https://github.com/carpentries/trainers/blob/main/powers_responsibilities.md#what-powers-belong-to-the-trainer-community)
+4. Identify meeting lead(s)
+	1. Trainer meeting leads is a community role that is filled by the [Trainers Leadership Committee](https://github.com/carpentries/trainers/blob/main/powers_responsibilities.md#what-responsibilities-belong-to-the-trainers-leadership-committee).
+	2. A brief [process for hosting meetings](https://pad.carpentries.org/trainers#L26) is described in the etherpad. 
+		1. Process is voluntary - a trainer reviews upcoming topics and signs up via GitHub to host a topic.
+			1. This references the same GitHub topic board as 2.2, above. Process may not be in current use.
+5. Hosting meetings

--- a/policy/trainers_meeting_guide.md
+++ b/policy/trainers_meeting_guide.md
@@ -20,7 +20,7 @@ Generated with assistance from ChatGPT, version 4o.
 - **Process**:
     1. Announce a call for topics via community channels (e.g., Slack, mailing lists).
     2. Encourage members to propose topics in the [trainers etherpad](https://pad.carpentries.org/trainers) under the "Propose a Topic" section.
-    3. Collect additional ideas from recent discussions, Slack threads, and survey feedback.
+    3. Collect additional ideas from recent discussions, Slack threads, survey feedback, and [active issues](https://github.com/carpentries/instructor-training/issues) in instructor training.
 - **Tips**:
     - Highlight any specific themes or areas of focus for upcoming meetings.
 


### PR DESCRIPTION
To replace the current outline in the policy directory.