### PR TITLE
Add December 2024 TLC minutes

### DIFF
--- a/leadership_minutes/2024/2024-12-13-leadership-minutes.md
+++ b/leadership_minutes/2024/2024-12-13-leadership-minutes.md
@@ -1,0 +1,37 @@
+
+Trainers Leadership 2024-12-13
+
+Attendance
+Present: Sher, Jon, Liz
+Apologies: Nathaniel
+### Agenda and notes
+
+1.  Core team update
+	1. [ITT website](https://tobyhodges.github.io/solid-spoon/training_info.html) (Sher!)
+		1. Many trainers don't use the workshop website, so this has been proposed as a way to reduce the admin overhead for trainers and Core Team.
+			1. Jon - main thing would miss the schedule. What would be missing from the learner's POV? The survey link?
+            2.  Liz - how does this change reporting?
+            3.  Sher - All that is in Amy, manually updated by Core Team. Different from technical workshop websites, which are automatic.
+            4.  Sher - Expect to implement in February 2025 meeting, let trainers know they no longer need to create websites.
+    2. [ITLC handbook](https://docs.google.com/document/d/1XAZKSM9xVXU1PB8EokfmZWKB8r8-_0KqilM7VIb2A48/edit?tab=t.0)
+	    1. Sher - Shared this a few months ago. In development, but not something that necessarily needs to be ready to go along with the rollout of the new Carpentries Handbook.
+        2. Liz - There isn't a mention of the TLC in the new Handbook. Much of the information is intended for individual trainers. Good to have mention of the community and the committee, especially as advocates for the trainers. Will submit a pull request to add a brief reference to the TLC and community.
+        3. Jon - not much time yet to have a look, but yeah, would be good to have community awareness pointing to the TLC. Might help with discussion of roles and how people can contribute
+2.  Current activities
+	1. [Draft trainer's meeting guide](https://github.com/carpentries/trainers/pull/310)
+		1. Jon prepared, with chatGPT; Nathaniel's comments look good, it's basically a detailed guide for current practice. Having done it a few times certainly helped me to write it.
+		2. Sher - I'm happy to read through from perspective of a novice
+    2.  [Places to cut from maintainers](https://codimd.carpentries.org/ttt-changes-working-dec2024?both)
+	    1. Discussion of how to process or incorporate feedback. What is the next step?
+        2. Create a table using [Liz example](https://docs.google.com/document/d/1afMeKMWkU4C9rFHqtEowVQaJLBw8S61jAlwpIovmoVs/edit?tab=t.0)
+        3. Tadah! [Trainer Preparation Schedule](https://docs.google.com/spreadsheets/d/1hVk-YkqIXGTJlv5Ocw73L4BF2x2sSWAEbkDvHzVUktM/edit?gid=0#gid=0)
+3.  Proposals and pull requests
+4.  Additional business
+	1. Discussion of TLC elections - unable to follow the current schedule for elections as given in the [governance](https://github.com/carpentries/trainers/blob/main/governance.md) document. Need to complete the process for updating trainer status first (to enable everyone to vote) and also getting a late start. Question of whether the current TLC can change the schedule or if that requires input and vote from the trainer community. Or if there is a middle solution.
+	2. Redaction check (standing item)
+	3. Confirm the next back up meeting
+5.  Action items (with responsible person and timeline)
+	1. Liz will submit a PR to add a brief statement about the TLC to the Handbook.
+	2. Jon will address changes and comments to the meeting guide PR. Deadline: January TLC meeting.
+	3. Sher to review the Trainers meeting guide
+6.  Next meeting: [January 17, 2025 01:30 UTC](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20250117T0130)


### PR DESCRIPTION
Adding the TLC meeting minutes from December, 2024. TLC review and approval requested - approval can be given here or in Slack.
