### PR TITLE
add March 2025 TLC minutes

### DIFF
--- a/leadership_minutes/2025/2025-03-20-leadership-minutes.md
+++ b/leadership_minutes/2025/2025-03-20-leadership-minutes.md
@@ -1,0 +1,38 @@
+Trainers Leadership March 2025-03-20
+
+Attendance
+Present: Sher, Jon, Liz
+Apologies: Nathaniel, Annajiat, Intekhab  
+Notetaker: Jon
+
+### Agenda and notes
+
+1.  Core team update
+2.  Current activities
+	1. [Trainers meeting guide](https://github.com/carpentries/trainers/pull/310): Still not done!
+		1. Anyone in TLC can have a look and accept revisions for merging the PR.
+			1. Some new content/info needs to be added re second monthly meeting default (send email when cancelling or when using?) and emailing the list (timing of communication).
+	2. TLC elections:
+		1. Sher will add nomination form and info to the newsletter
+		2. Currently one nominee - we need to add a name field to the form.
+			1. Need to push on Slack and Trainer's List (Topic Box).
+		3. What do we need to do between closing of nominations and the next trainers' meeting?
+			1.  At close of nominations liz collates list and shares with trainer community (list and email) also confirms meeting 3/4 April with candidates in an email.
+		4. TLC should start contacting people directly to encourage nominations.
+	3. Topic of the month for next trainers' meeting - meet the TLC candidates
+		1. If candidates can't attend, ask them to do a recording? Something to share with trainers. Or a write-up.
+			1. Recording a video could be a big ask. Could create barriers to participating.
+			2.  What has been done in the past - some recollection that candidates have added answers to questions in the etherpad when they couldn't make meetings.
+	4. Recommendations for what to cut from instructor training
+		1. We created a table/doc.
+		2. Need for a link or other pointer to this document.
+	5. Discussion of other topics of interest to community or standing/lingering issues.
+		1. Concept maps - Concept maps are a perennial difficulty for trainees. Any thoughts about how to make this more attainable? What has been tried before? I personally find them extremely valuable and wish I knew of a way to make them easier for people to learn about and use.
+			1. With many new trainers, this could be a good topic to revisit.
+		2. Resources in the instructor training GitHub repository for suggesting topics for trainer meetings.
+3.  Proposals and pull requests
+4.  Additional business
+	1. Redaction check (standing item).
+	2. Confirm the next back up meeting.
+5.  Action items (with responsible person and timeline)
+6.  Next meeting: [April 11, 01:00 UTC](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Carpentries+Teaching+Demo&iso=20250411T0100)

--- a/leadership_minutes/2025/2025-03-20-leadership-minutes.md
+++ b/leadership_minutes/2025/2025-03-20-leadership-minutes.md
@@ -24,7 +24,7 @@ Notetaker: Jon
 			1. Recording a video could be a big ask. Could create barriers to participating.
 			2.  What has been done in the past - some recollection that candidates have added answers to questions in the etherpad when they couldn't make meetings.
 	4. Recommendations for what to cut from instructor training
-		1. We created a table/doc.
+		1. We created a [table/doc](https://docs.google.com/spreadsheets/d/1hVk-YkqIXGTJlv5Ocw73L4BF2x2sSWAEbkDvHzVUktM/edit?usp=sharing).
 		2. Need for a link or other pointer to this document.
 	5. Discussion of other topics of interest to community or standing/lingering issues.
 		1. Concept maps - Concept maps are a perennial difficulty for trainees. Any thoughts about how to make this more attainable? What has been tried before? I personally find them extremely valuable and wish I knew of a way to make them easier for people to learn about and use.


### PR DESCRIPTION
Draft minutes from the 2025-03-20 meeting. Please approve here or in Slack.

I took the liberty of adding the next meeting date and time to the minutes, since either we didn't confirm or I forgot to make a note. With the change in the US to daylight savings time, please double check this for me.
