### PR TITLE
add May 20 2025 TLC minutes

### DIFF
--- a/leadership_minutes/2025/2025-05-20-leadership-minutes.md
+++ b/leadership_minutes/2025/2025-05-20-leadership-minutes.md
@@ -1,0 +1,87 @@
+Trainers Leadership May 2025-05-20
+
+Attendance
+Present: Liz, Jon, Sher, Jesse, Amanda, Cera, Annajiat
+Apologies: Nathaniel
+
+### Agenda and notes
+
+1. Introductions
+	1. Sher
+	2. Liz - based in Sydney Australia,
+	3. Jon - Albuquerque New Mexico - Have been on TLC as secretary this year. Instructor trainer since 2021
+	4. Amanda - Norman, Oklahoma. Instructor since 2023, and Trainer since 2024
+	5. Jesse - Blacksburg Virginia - digital humanities person. Carpentries Instructor since 2021 - became a trainer since last year
+	6. Cera: Norwest Connecticut - Based at Seven Bridges Genomics. Background in genomics.
+	7. Annajiat - Senior Lecturer in Information Sciences at BRAC University in Bangladesh
+2. Meeting Purpose/Structure
+	1. Core Team Updates
+		1. Sher - goal for meeting is to share Core Team Updates,
+		2. Give us the inside scoop from the Core Team
+	2. Discuss items from trainers slack channel
+	3. Plan Instructor Trainer meetings
+		1. TLC help determine topics for Instructor Trainers meetings
+	4. Review outstanding items
+	5. Project discussion
+		1. Undertake project work as a committee
+		2. Jon - routine business processes by posting notes via a review process. We follow a Martha's Rules process via pull requests on our github repo.
+		3. Catching up with Maintainers might belong on the standing agenda
+			1. Sher - we didn't do a lot of that this year, could be something to pick up this year.
+		4.  Help to promote Instructor Training sign-ups (Maneesha's emails, Slack messages)
+			1. We can send messages as well so it's not just coming from Maneesha, and so everyone can see the TLC is involved, too.
+	6. Routine business process
+		1. Post the notes, reviewed by the committee.
+		2. Generally tend to follow Martha's Rules
+	 7. Instructor Trainer Curriculum Maintainer
+	    1. Reach out to maintainer leads
+		    1. Add to the agenda to check-in regularly
+            2. Jesse is a R for Social Sciences maintainer
+	8. Review Trainer applications
+		1.   Won't be onboarding new Trainers in 2025
+		2. When we prepare for 2026, TLC will be asked first to support reviewing applications involved in this process.
+3. Meeting Roles:
+	1. Chair
+		1. What does the Chair do? See governance sheet in GitHub repo (https://github.com/carpentries/trainers/blob/main/governance.md)
+			1. Moderate meetings
+			2. Setting up the agenda with the Secretary
+				1. Try to do this a day before!
+			3. Serve as rep to Board of Directors Program Committee meetings
+				1. Or have open line of communication
+			4. Creating or updating public-facing committee information
+			5. Try to set monthly meetings
+				1. Sometimes meet in back-up meetings with Secretary
+					1. Difficulty: Time zones
+					2. Martha's rules to help with this
+					3. Committee projects go into Issues in the Trainers GitHub repository
+	2. Secretary
+		1. What does the Secretary do?
+			1. Make sure meetings are on the agenda
+			2. Make sure we connect through Slack about meetings
+			3. Call for agenda items for TLC meetings
+			4. Verify Trainers meetings (primary or secondary)
+			5. Send out announcements for meetings
+			6. Trade off on note-taking, though secretary will often take notes
+				1. Try to schedule beforehand if rotating note takers
+				2. Type them up nicely to post on GitHub
+	 3. Other discussion
+		 1. Important to note we were the first TLC after the significant change in Core Team Staffing, so a lot of our work went into supporting Sher and the new workshops and instruction team, as they had new and expanded roles.
+		 2. Added documentation about Trainers, TLC in handbook
+		 3. Review Sher's notes from Trainers meetings for approval and posting on GitHub
+		 4. Potential project: Recommendations for what to cut or shorten in the Instructor Training.
+			 1. Of concern to Trainers, especially newer ones
+			 2. Resources: 
+				 1. [Trainer Preparation Schedule](https://docs.google.com/spreadsheets/d/1hVk-YkqIXGTJlv5Ocw73L4BF2x2sSWAEbkDvHzVUktM/edit?gid=0#gid=0)
+				 2. [https://codimd.carpentries.org/ttt-changes-working-dec2024?both#](https://codimd.carpentries.org/ttt-changes-working-dec2024?both#)
+				 3. [Trainer planning and schedule 2024-09-10-ttt-online-AWST Instructor Training](https://docs.google.com/document/d/1afMeKMWkU4C9rFHqtEowVQaJLBw8S61jAlwpIovmoVs/edit?tab=t.0#heading=h.ibynwltc3tar)
+4. Actions
+	1. Update readme with 2025 membership: [https://github.com/carpentries/trainers/blob/main/README.md](https://github.com/carpentries/trainers/blob/main/README.md)
+	2. Blog Post with new members
+		1. [2024 blog example](https://carpentries.org/blog/2024/05/trainersleadershipcommittee/)
+		2. Can talk about this next week
+	3. Thursday monthly meetings
+		 1. Thursday @ this time seems to work for the new members & Sher
+		 2. Meet on Thursday 5/29
+		 3. Zoom meeting room 2
+		 4. Sher will send invite
+	4. Ask Maneesha for access to email list & the trainers repo
+	5. Think about how to fill the fifth seat


### PR DESCRIPTION
This PR adds draft minutes from the May 20, 2025 meeting between the outgoing and incoming Trainers Leadership Committee. Approval can be provided here or in Slack.
