### PR TITLE
Add 29 May 2025 TLC minutes

### DIFF
--- a/leadership_minutes/2025/2025-05-29-leadership-minutes.md
+++ b/leadership_minutes/2025/2025-05-29-leadership-minutes.md
@@ -1,7 +1,7 @@
 # Trainers Leadership Committee meeting, 29 May 2025
 
 - Attendance
-	- Present: Jon Wheeler, Amanda Kis, Jesse Sadler, Cera Fisher, Sher (running late)
+	- Present: Jon Wheeler, Amanda Kis, Jesse Sadler, Cera Fisher, SherAaron Hurt (running late)
 	- Apologies: 
 
 ## Agenda and notes
@@ -11,7 +11,7 @@
 	- Secretary: Jesse elected by consensus
 2. Go over process for approving minutes
     1. Export GoogleDoc with agenda to Markdown
-    2. Add minutes as separate document to leadership minutes folder on trainers GitHub for that year.
+    2. Add minutes as separate document to leadership minutes folder on Trainers GitHub for that year.
     3. Create pull request and add review to Trainers Leadership.
     4. Secretary pings committee when pull request is made.
     5. Review
@@ -28,9 +28,9 @@
     - Most of TLC will be at one or both meetings
     - Discussion topic: Teaching demos with only one or two people signed up.
 5. Proposals and pull requests
-    - Use of issues and pull requests in the trainers GitHub as a way to bring up points for discussion that can then be added to the meeting agenda.
+    - Use of issues and pull requests in the Trainers GitHub as a way to bring up points for discussion that can then be added to the meeting agenda.
 6. Action items
-    - Add current TLC to GitHub “trainers leadership” group. Jon will do this
+    - Add current TLC to GitHub "Trainers leadership" group. Jon will do this
     - Draft a general call for a committee member. Cera will compose a draft and post to Slack.
 7. Next meeting: June 27 00:00 UTC
     - Keep official meeting as Thursday before the trainer’s meeting.

--- a/leadership_minutes/2025/2025-05-29-leadership-minutes.md
+++ b/leadership_minutes/2025/2025-05-29-leadership-minutes.md
@@ -1,0 +1,37 @@
+# Trainers Leadership Committee meeting, 29 May 2025
+
+- Attendance
+	- Present: Jon Wheeler, Amanda Kis, Jesse Sadler, Cera Fisher, Sher (running late)
+	- Apologies: 
+
+## Agenda and notes
+
+1. Officer election
+	- Chair: Cera elected by consensus
+	- Secretary: Jesse elected by consensus
+2. Go over process for approving minutes
+    1. Export GoogleDoc with agenda to Markdown
+    2. Add minutes as separate document to leadership minutes folder on trainers GitHub for that year.
+    3. Create pull request and add review to Trainers Leadership.
+    4. Secretary pings committee when pull request is made.
+    5. Review
+        - Check that names and documents are redacted.
+        - Approval can be through pull request comments or on Slack
+        - Someone needs to merge
+        - If no comments are made for two weeks, pull request can be approved.
+3. Getting a fifth person on the committee
+    - Committee members will reach out to people.
+    - Would like to see more geographic diversity in the leadership committee.
+    - Should the first person to reach out be accepted?
+4. June Trainers meeting topic
+    - Call for 5th committee member. We will circulate a general call - we strongly invite and encourage a trainer from outside the US.
+    - Most of TLC will be at one or both meetings
+    - Discussion topic: Teaching demos with only one or two people signed up.
+5. Proposals and pull requests
+    - Use of issues and pull requests in the trainers GitHub as a way to bring up points for discussion that can then be added to the meeting agenda.
+6. Action items
+    - Add current TLC to GitHub “trainers leadership” group. Jon will do this
+    - Draft a general call for a committee member. Cera will compose a draft and post to Slack.
+7. Next meeting: June 27 00:00 UTC
+    - Keep official meeting as Thursday before the trainer’s meeting.
+    - Decide to remove standing backup meeting from calendar. Only schedule a second monthly meeting as needed.


### PR DESCRIPTION
This PR adds draft minutes from the 29 May 2025 meeting of the Trainers Leadership Committee. Approval can be provided here or in Slack.