### PR TITLE
Update voting members of ITLC in leader meeting rules

### DIFF
--- a/policy/leader_meeting_rules.md
+++ b/policy/leader_meeting_rules.md
@@ -56,10 +56,9 @@ to date.
 ## Suffrage
 
 1.  The following people are currently voting members of this project:
-    -   Liz Stokes
-    -   Annajiat Alim Rasel
-    -   Nathaniel Porter
-    -   Md Intekhabul Hafiz
+    -   Cera Fisher
+    -   Jesse Sadler
+    -   Amanda Kis
     -   Jon Wheeler
 
 2.  To become a voting member:


### PR DESCRIPTION
This PR updates the voting member of ITLC in the leader meeting rules document to the current membership. Approval can be provided here or in Slack.
