### PR TITLE
Add 29 August 2025 ITLC minutes

### DIFF
--- a/leadership_minutes/2025/2025-08-01-leadership-minutes.md
+++ b/leadership_minutes/2025/2025-08-01-leadership-minutes.md
@@ -2,7 +2,7 @@
 
 Present: Cera, Amanda, Jon, Jesse, Jannetta, Sher
 
-- ## Agenda and notes
+## Agenda and notes
 - Introductions: Welcome Jannetta!
 - Core team update
 	- Blog post

--- a/leadership_minutes/2025/2025-08-29-leadership-minutes.md
+++ b/leadership_minutes/2025/2025-08-29-leadership-minutes.md
@@ -1,0 +1,45 @@
+# Trainers Leadership Committee meeting, 29 August 2025
+
+- Present: Jon, Jesse, Amanda, Sher, Jannetta
+- Apologies: Cera
+
+## Agenda and notes
+
+- Core team update
+	- [Blogpost](https://carpentries.org/blog/2025/08/introducing-the-new-instructor-trainers-leadership-committee-for-2025/) 
+	- Learner Centered Training 
+		- Core Team looking at ways to offer trainings for learners who want to acquire the skills and pedagogy but not teach workshops. This is a large potential market.
+		- Aligns well with the “What to cut” project. Readjusting the order and what can be taken out about Carpentries and teaching workshops.
+			- But it is different in that goals are different.
+			- One full day of training.
+			- What to do for teaching demonstrations is a bit of an open question. Demonstrations are part of the pedagogy but less emphasis on teaching lessons.
+		- Goal is to have something for Q1. Pedagogy but not become instructor trainers.
+		- Will increase teaching opportunities for instructor trainers.
+		- Revenue source but membership will have access.
+- Current activities
+	- Review notes from last Instructor Trainers Meeting
+		- Three trainers meeting times to deal with time zones?
+			- Roll for someone in time zones that are currently less well served by current times. For example, a "meeting coordinator" role that would be less intensive than Core Team or ITLC roles.
+			- Gather some information on the geographic spread of trainers to see what time zones are less well served by current times.
+	- Potential discussion topics for next Trainers meetings
+		- How do we handle it when trainees miss more than one hour? What is the expectation for us or the Core Team, or the trainees themselves?
+			- Can miss 4 hours (2 hours/day for a two-day or 1 hour/day for a four-day) – Sher will ensure accuracy.
+			- Leaving notes in the attendance sheet helps the core team.
+		- How do you handle borderline (i.e., not sure whether to pass or ask to repeat) teaching demos?
+		- How to be detailed about attendance notes
+		- Deciding and communicating about borderline cases for accomplishing the training and teaching demo.
+			- How to communicate with co-instructor about when trainees come in and out?
+		- Presentation of topic: Managing borderline cases: instructor training and teaching demos
+- Proposals and pull requests
+	- PR #336: revise trainers meeting guide <https://github.com/carpentries/trainers/pull/336>
+- Additional business
+	- Redaction check (standing item)
+	- Confirm the next back up meeting 
+- Action items (with responsible person and timeline)
+	- Sher: Time zone data on trainers
+	- Jon: revise trainer meeting guide
+- Leaders for the trainers meetings?
+	- 4 September UTC 14:00: Jesse & Jannetta
+	- 4 September UTC 23:00: Jon (Amanda will help if she’s able to)
+- Next meeting: [Friday, 26 September, 17:30 UTC](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20250926T1730)
+	- Sher will be absent

--- a/leadership_minutes/2025/2025-08-29-leadership-minutes.md
+++ b/leadership_minutes/2025/2025-08-29-leadership-minutes.md
@@ -19,7 +19,7 @@
 - Current activities
 	- Review notes from last Instructor Trainers Meeting
 		- Three trainers meeting times to deal with time zones?
-			- Roll for someone in time zones that are currently less well served by current times. For example, a "meeting coordinator" role that would be less intensive than Core Team or ITLC roles.
+			- Role for someone in time zones that are currently less well served by current times. For example, a "meeting coordinator" role that would be less intensive than Core Team or ITLC roles.
 			- Gather some information on the geographic spread of trainers to see what time zones are less well served by current times.
 	- Potential discussion topics for next Trainers meetings
 		- How do we handle it when trainees miss more than one hour? What is the expectation for us or the Core Team, or the trainees themselves?


### PR DESCRIPTION
This PR adds draft minutes from the 29 August 2025 meeting of the Instructor Trainers Leadership Committee. Approval can be provided here or in Slack.