### PR TITLE
22 June 2026 ITLC minutes

### DIFF
--- a/leadership_minutes/2026/2026-06-01-leadership-minutes.md
+++ b/leadership_minutes/2026/2026-06-01-leadership-minutes.md
@@ -1,3 +1,5 @@
+# Trainers Leadership Committee meeting, 1 June 2026
+
 - Present: Jesse, Sher, Giorgia, Cera
 - Apologies: Amanda
 

--- a/leadership_minutes/2026/2026-06-22-leadership-minutes.md
+++ b/leadership_minutes/2026/2026-06-22-leadership-minutes.md
@@ -73,7 +73,4 @@
    2. DATE UTC 23:00: Amanda, Giorgia, Jesse, Cera
       - Sher will be here
 7. Next meeting: 27 July
-   - Amanda likely will not be here
-   - Giorgia will not be here
-   - Jesse will not be here
    - Might need to consider a different day

--- a/leadership_minutes/2026/2026-06-22-leadership-minutes.md
+++ b/leadership_minutes/2026/2026-06-22-leadership-minutes.md
@@ -1,0 +1,79 @@
+# Trainers Leadership Committee meeting, 22 June 2026
+
+- Present: Amanda, Cera, Giorgia, Sher
+- Apologies: Jesse
+- Guest:
+
+## Agenda and notes
+
+1. Core team update
+   - [Quarterly Governance Update Questionnaire](https://carpentries.typeform.com/to/FBKks5A8) for Amanda
+   - Review Github
+      - <https://github.com/carpentries/instructor-training/issues/1223\#issuecomment-3403549570>
+        1. Maybe quarterly, announcements \+ drive
+        2. Maybe at an extra monthly meeting, and then
+        3. Work asynchronously after
+        4. Great way to engage when trainers can’t attend a monthly meeting
+      - <https://github.com/carpentries/instructor-training/issues/1945\#issuecomment-462>
+   - GenAI discussions and bonus training
+      - Next AI Carpentry GenAI \+ Teaching Discussions on July 23
+      - Bonus modules still being scheduled by Toby - maybe will know Thursday, will share
+   - Three LCT on the schedule (one per month per quarter), some partnerships chose LCT
+      - Fit to different time zones
+      - Will adjust based on demand
+      - Currently being taught by Core Team
+      - Want Trainers to teach Instructor Training, where there is more demand and we struggle to get sign-ups sometimes
+   - Partnerships
+      - Can there be corporate partnerships?
+	  - Sher will check in on this
+2. Current activities
+   - Review notes from last Instructor Trainers Meeting
+      - Topics gathered from the meeting: see the above section under Garage on Topics for the year.
+      - Working on issues for instructor trainers repo together. Maybe something for a backup meeting. (Mid september?)
+      - **Series going through instructor trainer episodes (8 sections)**
+      - **Mentoring new trainers need, mentoring experienced trainers can give**
+      - How do you use Carpentries pedagogy and materials outside of Carpentries workshops?
+      - Demand and participation in activities in the Australia/New Zealand/South Pacific time zones – how can we improve activity and availability of community events in that part of the day-sphere?
+      - Digest of changes to Instructor Training curriculum
+      - **Revisiting teaching demos: What they are, what should we expect of trainees, discuss trends we're seeing, maybe as a quarterly topic**
+   - Potential discussion topics for next Trainers meetings
+      - Mentoring (new) trainers (**August**)
+      - Revisiting teaching demos – decided to go with this one for **July** meeting
+        - Not passing someone—how to make that decision
+        - Time management with a full group
+        - Canceling when there are no or few sign-ups — assure them this is not abnormal (1–2 month)
+      - Series of Instructor Training episodes like book club, once a quarter so everyone can prepare (**September**)
+        - Encourage them to skim before
+        - Talk through sticky points
+        - What to emphasize
+        - What could be cut
+        - Tips and tricks that have worked well (or not well)
+3. Proposals and pull requests
+   - From Slack: One thing that has come up in the feedback for current workshop is homework; it was unexpected by the learners. Should it be mentioned on the info email with the training session details?
+      - Amanda had similar feedback in last training
+      - Put in the email to trainees: Expect to spend 20–30 min each day between training sessions preparing for the next day
+        - Also add a line to the Summary and Setup section in the Instructor Training curriculum
+      - Put it in an expected time commitment section?
+        - 16 hours in class
+        - 20–30 min between sessions
+      - Could also add a section about expectations for training
+        - Interactive
+        - Discussions
+        - Breakout rooms
+   - From June 4 Instructor Trainers meeting: Have we considered having a day break between Days 1 and 2 of Instructor Training? Might work nicely with school schedules and give learners a break to digest
+4. Additional business
+   - Redaction check (standing item)
+5. Action items (with responsible person and timeline)
+   - Sher will bring a "bibliography drive" to an upcoming Core Team meeting
+   - Sher will add descriptions to the email that goes to learners for instructor training and the Summary and Setup about spending 20–30 min of prep time between sessions, expected time commitment in training and between training, expectations for training re: discussions, breakout rooms
+   - Sher will ask about corporate partnerships
+6. Leaders for the trainers meetings?
+   1. DATE UTC 14:00: Amanda, Jesse, maybe Cera
+      - Sher will be here
+   2. DATE UTC 23:00: Amanda, Giorgia, Jesse, Cera
+      - Sher will be here
+7. Next meeting: 27 July
+   - Amanda likely will not be here
+   - Giorgia will not be here
+   - Jesse will not be here
+   - Might need to consider a different day


### PR DESCRIPTION
This PR adds draft minutes from the 22 June 2026 meeting of the Instructor Trainers Leadership Committee. Approval can be provided by reviewing the PR.